### PR TITLE
feat: add environment variable support for auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A CLI tool to manage and run Claude Code with different contexts.
 
 - List available contexts from a configuration file
 - Run Claude Code with a specific context temporarily
+- Support for environment variables in authentication tokens for enhanced security
 
 ## Installation
 
@@ -26,7 +27,11 @@ auth_token = "work-token-here"
 
 [context.personal]
 base_url = "https://api.anthropic.com"
-auth_token = "personal-token-here"
+auth_token = "env:ANTHROPIC_PERSONAL_TOKEN"
+
+[context.staging]
+base_url = "https://api.anthropic.com"
+auth_token = "env:ANTHROPIC_STAGING_TOKEN"
 ```
 
 ## Usage
@@ -63,6 +68,27 @@ In interactive mode (when no context name is provided), you can:
 
 All arguments after the `--` separator are forwarded to Claude, allowing you to use Claude's full functionality.
 For example: `ccctx run personal -- --help` or `ccctx run -- --version`
+
+## Environment Variables in Authentication
+
+For enhanced security, you can use environment variables instead of hardcoding authentication tokens in your configuration file. Use the `env:` prefix followed by the environment variable name:
+
+```toml
+[context.production]
+base_url = "https://api.anthropic.com"
+auth_token = "env:ANTHROPIC_API_KEY"
+```
+
+When using this format:
+- The tool will read the value from the specified environment variable
+- If the environment variable is not set or empty, an error will be displayed
+- This prevents accidentally committing sensitive tokens to version control
+
+**Important:** Make sure to export the environment variable in your shell:
+```bash
+export ANTHROPIC_API_KEY="your-api-key-here"
+# Or add to your ~/.bashrc file
+```
 
 ## Environment Variables
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveEnvVar(t *testing.T) {
+	// Save and restore environment variables
+	originalTestToken := os.Getenv("TEST_TOKEN")
+	originalEmptyToken := os.Getenv("EMPTY_TOKEN")
+	defer func() {
+		if originalTestToken != "" {
+			os.Setenv("TEST_TOKEN", originalTestToken)
+		} else {
+			os.Unsetenv("TEST_TOKEN")
+		}
+		if originalEmptyToken != "" {
+			os.Setenv("EMPTY_TOKEN", originalEmptyToken)
+		} else {
+			os.Unsetenv("EMPTY_TOKEN")
+		}
+	}()
+
+	// Set up test environment variables
+	os.Setenv("TEST_TOKEN", "test-token-value")
+	os.Setenv("EMPTY_TOKEN", "")
+
+	tests := []struct {
+		name        string
+		input       string
+		want        string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "regular value without env prefix",
+			input:   "direct-token-value",
+			want:    "direct-token-value",
+			wantErr: false,
+		},
+		{
+			name:    "valid environment variable",
+			input:   "env:TEST_TOKEN",
+			want:    "test-token-value",
+			wantErr: false,
+		},
+		{
+			name:        "empty environment variable name",
+			input:       "env:",
+			wantErr:     true,
+			errContains: "environment variable name cannot be empty",
+		},
+		{
+			name:        "missing environment variable",
+			input:       "env:MISSING_TOKEN",
+			wantErr:     true,
+			errContains: "environment variable 'MISSING_TOKEN' is not set or empty",
+		},
+		{
+			name:        "empty environment variable value",
+			input:       "env:EMPTY_TOKEN",
+			wantErr:     true,
+			errContains: "environment variable 'EMPTY_TOKEN' is not set or empty",
+		},
+		{
+			name:    "env prefix in middle of string",
+			input:   "some-env:text",
+			want:    "some-env:text",
+			wantErr: false,
+		},
+		{
+			name:    "value starting with env but not colon",
+			input:   "envtext",
+			want:    "envtext",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveEnvVar(tt.input)
+			
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("resolveEnvVar() expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && err.Error() != tt.errContains {
+					t.Errorf("resolveEnvVar() error = %v, want error containing %v", err, tt.errContains)
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("resolveEnvVar() unexpected error = %v", err)
+				return
+			}
+			
+			if got != tt.want {
+				t.Errorf("resolveEnvVar() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add support for using environment variables in auth_token configuration via 'env:' prefix. This enhances security by allowing users to store sensitive tokens in environment variables instead of config files.

- Add resolveEnvVar function to parse environment variable references
- Update GetContext to resolve environment variables with proper error handling
- Add comprehensive unit tests for environment variable resolution
- Update README.md with documentation and examples
- Maintain backward compatibility with direct token values

Closes: #1 