### PR TITLE
feat: add optional model configuration support for contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ Example configuration:
 [context.work]
 base_url = "https://api.anthropic.com"
 auth_token = "work-token-here"
+model = "claude-3-5-sonnet-20241022"
 
 [context.personal]
 base_url = "https://api.anthropic.com"
 auth_token = "env:ANTHROPIC_PERSONAL_TOKEN"
+model = "claude-3-5-haiku-20241022"
+small_fast_model = "claude-3-5-haiku-20241022"
 
 [context.staging]
 base_url = "https://api.anthropic.com"
@@ -68,6 +71,23 @@ In interactive mode (when no context name is provided), you can:
 
 All arguments after the `--` separator are forwarded to Claude, allowing you to use Claude's full functionality.
 For example: `ccctx run personal -- --help` or `ccctx run -- --version`
+
+## Model Configuration
+
+You can optionally specify model preferences for each context using the `model` and `small_fast_model` fields:
+
+```toml
+[context.production]
+base_url = "https://api.anthropic.com"
+auth_token = "env:ANTHROPIC_API_KEY"
+model = "claude-3-5-sonnet-20241022"
+small_fast_model = "claude-3-5-haiku-20241022"
+```
+
+When these fields are provided:
+- `model` sets the `ANTHROPIC_MODEL` environment variable
+- `small_fast_model` sets the `ANTHROPIC_SMALL_FAST_MODEL` environment variable
+- Both fields are optional - if not provided, the environment variables won't be set
 
 ## Environment Variables in Authentication
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -154,11 +154,13 @@ var RunCmd = &cobra.Command{
 		// Start with a clean environment based on the current one
 		env := os.Environ()
 		
-		// Remove any existing ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN
+		// Remove any existing ANTHROPIC environment variables
 		newEnv := []string{}
 		for _, e := range env {
 			if !(len(e) >= 19 && e[:19] == "ANTHROPIC_BASE_URL=") && 
-			   !(len(e) >= 20 && e[:20] == "ANTHROPIC_AUTH_TOKEN=") {
+			   !(len(e) >= 20 && e[:20] == "ANTHROPIC_AUTH_TOKEN=") &&
+			   !(len(e) >= 15 && e[:15] == "ANTHROPIC_MODEL=") &&
+			   !(len(e) >= 28 && e[:28] == "ANTHROPIC_SMALL_FAST_MODEL=") {
 				newEnv = append(newEnv, e)
 			}
 		}
@@ -166,6 +168,14 @@ var RunCmd = &cobra.Command{
 		// Add the new context variables
 		newEnv = append(newEnv, fmt.Sprintf("ANTHROPIC_BASE_URL=%s", ctx.BaseURL))
 		newEnv = append(newEnv, fmt.Sprintf("ANTHROPIC_AUTH_TOKEN=%s", ctx.AuthToken))
+		
+		// Add model variables if configured
+		if ctx.Model != "" {
+			newEnv = append(newEnv, fmt.Sprintf("ANTHROPIC_MODEL=%s", ctx.Model))
+		}
+		if ctx.SmallFastModel != "" {
+			newEnv = append(newEnv, fmt.Sprintf("ANTHROPIC_SMALL_FAST_MODEL=%s", ctx.SmallFastModel))
+		}
 
 		// Execute claude with the modified environment and forwarded args
 		cmdClaude := exec.Command(claudePath, claudeArgs...)

--- a/config/config.go
+++ b/config/config.go
@@ -10,8 +10,10 @@ import (
 )
 
 type Context struct {
-	BaseURL   string `mapstructure:"base_url"`
-	AuthToken string `mapstructure:"auth_token"`
+	BaseURL        string `mapstructure:"base_url"`
+	AuthToken      string `mapstructure:"auth_token"`
+	Model          string `mapstructure:"model"`
+	SmallFastModel string `mapstructure:"small_fast_model"`
 }
 
 type Config struct {
@@ -68,6 +70,9 @@ func LoadConfig() (*Config, error) {
 [context.example]
 base_url = "https://api.anthropic.com"
 auth_token = "your-auth-token-here"
+# Optional: specify model explicitly
+# model = "claude-3-5-sonnet-20241022"
+# small_fast_model = "claude-3-5-haiku-20241022"
 `
 		if err := os.WriteFile(configPath, []byte(defaultConfig), 0644); err != nil {
 			return nil, err
@@ -121,8 +126,10 @@ func GetContext(name string) (*Context, error) {
 	}
 
 	resolvedContext := Context{
-		BaseURL:   context.BaseURL,
-		AuthToken: resolvedAuthToken,
+		BaseURL:        context.BaseURL,
+		AuthToken:      resolvedAuthToken,
+		Model:          context.Model,
+		SmallFastModel: context.SmallFastModel,
 	}
 
 	return &resolvedContext, nil


### PR DESCRIPTION
- Add  and  fields to context configuration
- Set ANTHROPIC_MODEL and ANTHROPIC_SMALL_FAST_MODEL environment variables
- Update environment variable filtering to handle new model variables
- Document model configuration usage in README with examples
- Maintain backward compatibility - model fields are optional

Closes: #3 