### PR TITLE
Finish Epic 3

### DIFF
--- a/_bmad-output/implementation-artifacts/3-1-runner-and-command-layer-robustness.md
+++ b/_bmad-output/implementation-artifacts/3-1-runner-and-command-layer-robustness.md
@@ -1,0 +1,255 @@
+# Story 3.1: Runner & Command Layer Robustness
+
+Status: done
+
+## Story
+
+As a **developer**,
+I want **runner 包和 cmd 包的健壮性问题得到修复，包括输入验证、错误处理、flag 解析和测试覆盖**,
+So that **后续 Story 3.2 的 --model flag 添加能在稳固的基础上进行，且 ParseArgs 的 flag 处理方式不会与 Cobra flag 冲突**.
+
+## Acceptance Criteria
+
+1. **AC1: BaseURL format validation in runner.New()** — `New()` validates that `BaseURL` is a valid URL (has scheme, no spaces). Invalid URLs return a clear validation error before creating a Runner. [Source: deferred-work.md — "runner.New does not validate BaseURL format"]
+
+2. **AC2: No double-printing of non-ExitError failures** — When `runner.Run()` returns a non-ExitError (e.g., binary not found), the error message is printed exactly once by the caller (`cmd/*.go`). The runner itself never prints to stderr/stdout. [Source: deferred-work.md — "runner.Run double-prints non-ExitError failures"]
+
+3. **AC3: ParseArgs rejects or handles flag-like args in provider position** — When `ParseArgs` receives args starting with `-` in the provider position (before `--`), it either rejects them with a clear error or handles them in a defined way that Story 3.2 can build on. This is the **critical prerequisite** for adding `--model` flags. [Source: deferred-work.md — "ParseArgs treats flags before `--` as context names"]
+
+4. **AC4: No direct os.Exit in cmd/exec.go error paths** — Error handling in `cmd/exec.go` uses `return` with exit code propagation instead of direct `os.Exit()`, ensuring any deferred cleanup functions execute. `os.Exit()` is called only at the top level of the `Run` function. [Source: deferred-work.md — "os.Exit calls bypass future defer cleanup"]
+
+5. **AC5: cmd/run.go table-driven tests** — New test file `cmd/run_test.go` with table-driven tests covering: success path (provider found, claude found), context not found, TUI cancellation, LookPath failure. Uses testify framework. [Source: deferred-work.md — "cmd/run.go has no automated tests"]
+
+6. **AC6: All tests pass** — `go test ./...` passes, `go vet ./...` clean, `make build` succeeds.
+
+7. **AC7: Existing behavior unchanged** — `ccctx run <provider>`, `ccctx exec <provider>`, `ccctx run` (TUI), `ccctx exec` (TUI) all work identically to current behavior.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add URL validation in runner.New() (AC: #1)
+  - [x] RED: Write table-driven tests in `runner_test.go` first — test `validateURL` directly (cases: valid URL, missing scheme, contains spaces, empty string) and optionally test `New()` with invalid URLs. For `New()` tests: create a temp TOML config file with contexts containing invalid `base_url` values, and use `t.Setenv("CCCTX_CONFIG_PATH", tempFile)` before calling `New()`. Alternatively, focus RED tests on `validateURL` directly and defer `New()` integration tests to a separate test function. Run tests, confirm failures (function doesn't exist yet).
+  - [x] GREEN: Import `net/url`, implement `validateURL` helper (parse URL, check scheme non-empty, check no spaces), wire into `New()` after resolving context, before `buildEnv()`. Run tests, confirm all pass.
+  - [x] REFACTOR: Clean up if needed.
+
+- [x] Task 2: Verify and document single-print error contract (AC: #2)
+  - [x] Audit `runner.Run()` — already correct: returns `(int, error)` without printing
+  - [x] Audit `cmd/exec.go` and `cmd/run.go` — confirm each error path prints exactly once
+  - [x] Minimal code change: verify the existing contract via audit, then add a documentation comment in `runner.go` near `Run()`
+  - [x] Add a comment in `runner.go` near `Run()`: `// Run executes the target command. Returns (0, nil) on success, (exitCode, nil) for command exit errors, (1, error) for start failures. Caller is responsible for printing errors.`
+
+- [x] Task 3: Update ParseArgs to handle flag-like args (AC: #3)
+  - [x] RED: Add failing test cases in `args_test.go` for flag-like args in provider position: `["--model", "foo"]` (wantErr contains `"flag-like argument"`), `["-m"]` (wantErr contains `"flag-like argument '-m'"`), `["--model", "--", "foo"]` (wantErr contains `"flag-like argument '--model'"`). Each test expects a non-empty error containing the flag name. Run tests, confirm failures.
+  - [x] GREEN: In `ParseArgs`, when the resolved provider argument (the single argument before `--`, or `args[0]` when `--` is absent) starts with `-`, return an error: `"flag-like argument '%s' not allowed in provider position"`. Run tests, confirm all pass.
+  - [x] REFACTOR: Ensure error message consistency.
+  - [x] Note: This makes `ccctx run --model` fail explicitly instead of treating `--model` as a provider name. Story 3.2 will change this behavior to accept and parse flags — but the current rejection establishes the pattern.
+
+- [x] Task 4: Refactor cmd/exec.go to avoid direct os.Exit in error paths (AC: #4)
+  - [x] Extract the `Run` function body into a helper that returns exit code (int)
+  - [x] Call `os.Exit(result)` once at the top level
+  - [x] Same pattern for `cmd/run.go` if it has the same issue
+  - [x] Ensure deferred functions (if any) execute before exit
+
+- [x] Task 5: Add cmd/run_test.go (AC: #5)
+  - [x] Refactor `cmd/run.go` to extract `runRun(args []string) int` (same pattern as Task 4)
+  - [x] Test `runRun` directly — it returns exit code, no `os.Exit` in test path
+  - [x] Use `CCCTX_CONFIG_PATH` env var to point at a temp test config file with known contexts
+  - [x] For LookPath testing: create a temp dir, symlink/write a fake `claude` binary, set `PATH` via `t.Setenv("PATH", tmpDir)`
+  - [x] Test cases: success path (provider found, claude found), context not found, LookPath failure, ParseArgs error
+  - [x] Note: TUI cancel path cannot be unit-tested because `ui.RunContextSelector` requires an interactive terminal (`tview.Application.Run()`). The cancel path is covered by manual smoke testing in Task 6. The `errors.Is(err, ui.ErrCancelled)` branch in `runRun` is a simple 3-line if-block — low risk.
+  - [x] Note: Use `package cmd` (not `package cmd_test`) in `cmd/run_test.go` so tests can call the unexported `runRun` function.
+  - [x] Note: cmd/exec.go tests can be deferred — this story focuses on run.go since it was explicitly called out
+
+- [x] Task 6: Verify all tests and build (AC: #6, #7)
+  - [x] `go test ./...` passes
+  - [x] `go vet ./...` clean
+  - [x] `make build` succeeds
+  - [x] Manual smoke test: `ccctx run`, `ccctx exec`, argument forwarding
+
+## Dev Notes
+
+### Current State
+
+Epic 1 and Epic 2 are complete. The runner package (`internal/runner/`) and command files (`cmd/run.go`, `cmd/exec.go`) work correctly for all current use cases. This story addresses deferred code review items that are prerequisites for adding `--model` flag support in Story 3.2.
+
+### Key Files
+
+| File | Role | Change Type |
+|------|------|-------------|
+| `internal/runner/runner.go` | Runner struct, New(), Run(), buildEnv() | MODIFY — add URL validation |
+| `internal/runner/args.go` | ParseArgs() | MODIFY — reject flag-like args in provider position |
+| `internal/runner/runner_test.go` | Tests for buildEnv | MODIFY — add URL validation tests |
+| `internal/runner/args_test.go` | Tests for ParseArgs | MODIFY — add flag-like arg test cases |
+| `cmd/exec.go` | exec subcommand | MODIFY — refactor os.Exit pattern |
+| `cmd/run.go` | run subcommand | MODIFY — refactor os.Exit pattern |
+| `cmd/run_test.go` | Tests for run command | NEW — table-driven tests |
+
+### URL Validation Strategy
+
+Use `net/url.Parse()` to validate BaseURL in `runner.New()`:
+
+```go
+func validateURL(rawURL string) error {
+    if strings.Contains(rawURL, " ") {
+        return fmt.Errorf("invalid base_url: contains spaces")
+    }
+    u, err := url.Parse(rawURL)
+    if err != nil {
+        return fmt.Errorf("invalid base_url: %w", err)
+    }
+    if u.Scheme == "" {
+        return fmt.Errorf("invalid base_url: missing scheme (e.g., https://)")
+    }
+    return nil
+}
+```
+
+Insert in `New()` between the `ctx.AuthToken == ""` check (line 34) and the `len(opts.Target) == 0` check (line 37). This validates the URL before `buildEnv()` uses it.
+
+### ParseArgs Flag Handling Strategy
+
+The critical design question: how should `ParseArgs` treat `--model foo`?
+
+**Current behavior:** `ParseArgs(["--model", "foo"])` returns `provider="--model", targetArgs=["foo"]` — treats `--model` as a provider name, which will fail at `config.GetContext("--model")` with a confusing error.
+
+**Story 3.1 approach:** Reject flag-like args explicitly. When the resolved provider argument (the single argument before `--`, or `args[0]` when `--` is absent) starts with `-`, return an error: `"flag-like argument '%s' not allowed in provider position"`. This:
+- Gives a clear error message instead of confusing "context not found"
+- Establishes the pattern that flags in provider position are special
+- Story 3.2 will change this to parse `--model` and `--small-fast-model` before calling ParseArgs (likely via `cmd.DisableFlagParsing = true` with manual flag extraction)
+
+### os.Exit Refactor Pattern
+
+```go
+// BEFORE (cmd/exec.go):
+Run: func(cmd *cobra.Command, args []string) {
+    // ... error handling with direct os.Exit(1) calls ...
+    os.Exit(exitCode)
+},
+
+// AFTER:
+Run: func(cmd *cobra.Command, args []string) {
+    os.Exit(execRun(args))
+},
+
+func execRun(args []string) int {
+    // ... all logic with return 1 on error, return exitCode on success ...
+}
+```
+
+This pattern ensures any `defer` statements in `execRun` execute before `os.Exit`. Currently there are no defers, but this establishes the pattern for future use (e.g., cleanup in Story 3.2).
+
+### cmd/run_test.go Testing Strategy
+
+Testing `cmd/run.go` is challenging because it calls `os.Exit`. Options:
+
+1. **Extract logic into testable function** (recommended) — same pattern as Task 4. Extract `runRun(args []string) int` and test that function directly.
+2. **Use os/exec to run the binary** — integration test approach, slower but realistic.
+
+Recommend approach 1: after Task 4 refactors `run.go` to extract `runRun(args) int`, test `runRun` directly by:
+- Setting up test config via `CCCTX_CONFIG_PATH`
+- Mocking `exec.LookPath` by controlling PATH
+- Testing TUI paths by checking the error flow
+
+### Deferred Work Items Source
+
+All items in this story come from `deferred-work.md` and were promoted from code reviews of Stories 1.1-1.4:
+
+| Deferred Item | Source Review | AC |
+|---------------|---------------|-----|
+| runner.New does not validate BaseURL format | Story 1-1 review | AC1 |
+| runner.Run double-prints non-ExitError failures | Story 1-3 review | AC2 |
+| ParseArgs treats flags before `--` as context names | Story 1-3 review | AC3 |
+| os.Exit calls bypass future defer cleanup | Story 1-3 review | AC4 |
+| cmd/run.go has no automated tests | Story 1-1 review | AC5 |
+
+### Previous Story Intelligence
+
+From Story 2-2 implementation:
+- TUI selector uses sentinel error `ErrCancelled` — tested via `errors.Is` in both cmd files
+- Cancellation messages moved to stderr in both `cmd/run.go:42` and `cmd/exec.go:39`
+- All error output uses `fmt.Fprintf(os.Stderr, ...)` or `fmt.Fprintln(os.Stderr, ...)`
+
+From Story 1-3 implementation:
+- Runner struct carries `ctx`, `opts`, `env` — `New()` validates BaseURL and AuthToken non-empty
+- `Run()` returns `(int, error)` — ExitError returns exit code, other errors return `(1, err)`
+- `ParseArgs()` is command-agnostic — no cmdType parameter
+- Both `cmd/run.go` and `cmd/exec.go` follow identical error handling pattern
+
+From Story 1-2 implementation:
+- `cmd/run.go` is ~74 lines — thin wrapper calling `runner.ParseArgs`, TUI, `LookPath`, `runner.New`, `runner.Run`
+- Error format: `fmt.Fprintf(os.Stderr, "Error: %v\n", err)` — consistent across both commands
+
+### Anti-Patterns (Do NOT)
+
+- Do NOT add `--model` flag support in this story — that's Story 3.2
+- Do NOT modify `internal/ui/selector.go` — not in scope
+- Do NOT modify `config/config.go` — not in scope
+- Do NOT call `os.Exit()` inside `internal/runner/` — breaks testability
+- Do NOT use `fmt.Fprintf(os.Stderr, ...)` inside runner — commands own output
+- Do NOT over-engineer the test mocking — keep tests simple and direct
+- Do NOT change the `buildEnv` injection order — it's established and tested
+- Do NOT change TUI cancellation exit code from 1 to 0 — this was an intentional breaking change applied in Epic 2
+
+### Project Structure Notes
+
+- All changes are in existing packages (`internal/runner/`, `cmd/`)
+- New file `cmd/run_test.go` follows the established test naming convention
+- URL validation uses stdlib `net/url` — no new dependencies
+- Go 1.23.3 target — `min()`/`max()` builtins available if needed
+
+### References
+
+- [Source: internal/runner/runner.go:31-36] — New() validation, needs URL check
+- [Source: internal/runner/runner.go:44-60] — Run() error return pattern
+- [Source: internal/runner/args.go:30-34] — ParseArgs "no args" path, needs flag detection
+- [Source: cmd/exec.go:19-69] — exec command, needs os.Exit refactor
+- [Source: cmd/run.go:20-74] — run command, needs os.Exit refactor + tests
+- [Source: internal/runner/runner_test.go] — existing buildEnv tests
+- [Source: internal/runner/args_test.go] — existing ParseArgs tests
+- [Source: _bmad-output/implementation-artifacts/deferred-work.md] — deferred items source
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 3.1] — epic story definition
+- [Source: _bmad-output/planning-artifacts/architecture.md#AD1] — Runner struct design
+- [Source: _bmad-output/planning-artifacts/architecture.md#Phase 2] — known --model vs -- conflict
+- [Source: _bmad-output/project-context.md] — implementation rules and patterns
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GLM-5.1
+
+### Debug Log References
+
+### Completion Notes List
+
+- Task 1: Added `validateURL()` helper using `net/url.Parse()` with scheme and space checks. Wired into `New()` between BaseURL empty check and AuthToken check. 7 table-driven test cases pass.
+- Task 2: Audited `runner.Run()`, `cmd/exec.go`, `cmd/run.go` — single-print contract already correct. Added documentation comment on `Run()` method.
+- Task 3: Added flag-like arg detection in `ParseArgs` — when provider position arg starts with `-`, returns clear error message. 3 new test cases (double dash, single dash, with separator).
+- Task 4: Extracted `execRun(args) int` and `runRun(args) int` helpers from Cobra `Run` closures. `os.Exit()` called only at top level now.
+- Task 5: Created `cmd/run_test.go` with 7 table-driven test cases covering ParseArgs error, context not found, LookPath failure, success, non-zero exit code, missing base_url, invalid URL format.
+- Task 6: All 32 tests pass, `go vet` clean, `make build` succeeds.
+
+### Review Findings
+
+- [x] [Review][Patch] `cmd/run_test.go` 缺少带 `--` 分隔符和转发参数的成功路径测试 [cmd/run_test.go] — 应添加 `args: []string{"test", "--", "--model", "foo"}` 等用例验证参数正确转发到 claude
+- [x] [Review][Patch] `cmd/run_test.go` 缺少 auth_token 缺失的测试用例 [cmd/run_test.go] — 现有测试覆盖 missing base_url 和 invalid base_url，但未覆盖 auth_token 为空的情况
+- [x] [Review][Defer] 跨平台兼容性：Windows 上假 claude 脚本使用 shebang 不工作 [cmd/run_test.go] — deferred, pre-existing
+- [x] [Review][Defer] buildEnv 不验证注入环境变量值中的换行或空字节 [internal/runner/runner.go:82-99] — deferred, pre-existing
+- [x] [Review][Defer] config 对 base_url 不支持 env: 前缀解析（与 auth_token 不一致） [config/config.go] — deferred, pre-existing
+- [x] [Review][Defer] SHELL 环境变量可执行性未验证 [cmd/exec.go:52-58] — deferred, pre-existing
+- [x] [Review][Defer] 目标命令被信号终止时退出码丢失 [internal/runner/runner.go:64-80] — deferred, pre-existing
+- [x] [Review][Defer] 空 provider 名未在 ParseArgs 中显式拒绝 [internal/runner/args.go] — deferred, pre-existing
+- [x] [Review][Defer] 通用 "Error: %v" 消息模式不利于程序化错误区分 [cmd/run.go, cmd/exec.go] — deferred, pre-existing
+
+### File List
+
+- `internal/runner/runner.go` — MODIFIED: added `validateURL()`, imported `net/url`, wired into `New()`, added `Run()` doc comment
+- `internal/runner/args.go` — MODIFIED: added flag-like arg detection in provider position, imported `strings`
+- `internal/runner/runner_test.go` — MODIFIED: added `TestValidateURL` with 7 test cases, added `require` import
+- `internal/runner/args_test.go` — MODIFIED: added 3 flag-like arg test cases
+- `cmd/exec.go` — MODIFIED: extracted `execRun()` helper, `os.Exit()` only at top level
+- `cmd/run.go` — MODIFIED: extracted `runRun()` helper, `os.Exit()` only at top level
+- `cmd/run_test.go` — NEW: 7 table-driven test cases for run command
+
+### Change Log
+
+- 2026-04-20: Implemented all 6 tasks — URL validation (AC1), single-print contract audit (AC2), flag-like arg rejection (AC3), os.Exit refactor (AC4), run_test.go (AC5), full validation (AC6/AC7)

--- a/_bmad-output/implementation-artifacts/3-2-add-model-override-flags-to-run-and-exec.md
+++ b/_bmad-output/implementation-artifacts/3-2-add-model-override-flags-to-run-and-exec.md
@@ -1,0 +1,414 @@
+# Story 3.2: Add --model Override Flags to run and exec
+
+Status: done
+
+## Story
+
+As a **ccctx user**,
+I want **to override the provider's configured model via `--model <value>` and `--small-fast-model <value>` flags on `run` and `exec` commands**,
+so that **I can quickly switch models without editing the config file**.
+
+## Acceptance Criteria
+
+1. **AC1: --model flag overrides config model** — Given provider-A has `model = "claude-sonnet-4-6"` in config, `ccctx run provider-A --model claude-opus-4-7` sets `ANTHROPIC_MODEL=claude-opus-4-7` in the child process. [Source: epics.md#Story 3.2, FR27]
+
+2. **AC2: --model flag sets model when config has none** — Given provider-A has no `model` configured, `ccctx exec provider-A --model claude-opus-4-7 -- env | grep ANTHROPIC_MODEL` outputs `ANTHROPIC_MODEL=claude-opus-4-7`. [Source: epics.md#Story 3.2]
+
+3. **AC3: --small-fast-model flag works** — Given provider-A has `small_fast_model = "claude-haiku-4-5"`, `ccctx run provider-A --small-fast-model claude-sonnet-4-6` sets `ANTHROPIC_SMALL_FAST_MODEL=claude-sonnet-4-6`. [Source: epics.md#Story 3.2]
+
+4. **AC4: CLI flags take priority over config** — When both CLI flag and config value exist, CLI flag wins. Priority chain: `Options.Model > ctx.Model > omit` (same for SmallFastModel). [Source: architecture.md#Model priority, FR28]
+
+5. **AC5: No flags = config values used** — When no flags specified, config file values are used (existing behavior unchanged). [Source: epics.md#Story 3.2]
+
+6. **AC6: Flags available on both commands** — `--model` and `--small-fast-model` work identically on both `run` and `exec`. [Source: FR27, FR28]
+
+7. **AC7: --model with TUI mode** — `ccctx run --model claude-opus-4-7` (no provider) opens TUI selector, and the selected provider runs with the overridden model.
+
+8. **AC8: -- separator not consumed by flag parsing** — `ccctx exec provider-A --model claude-opus-4-7 -- env | grep ANTHROPIC_MODEL` correctly forwards `env | grep ANTHROPIC_MODEL` as the target command, not consumed by flag parsing. [Source: architecture.md#Phase 2 conflict]
+
+9. **AC9: All existing tests pass** — `go test ./...` passes, `go vet ./...` clean, `make build` succeeds.
+
+10. **AC10: New table-driven tests** — Tests cover flag extraction, priority chain, and integration with both commands.
+
+## Tasks / Subtasks
+
+- [x] Task 1: RED — write failing tests for ExtractFlags and WantsHelp in args_test.go (AC: #8, #10)
+  - [x] Table-driven tests for `ExtractFlags` in `args_test.go` covering:
+    - No flags → returns empty strings, args unchanged
+    - `--model foo provider-A` → model="foo", remaining=["provider-A"]
+    - `provider-A --model foo` → model="foo", remaining=["provider-A"]
+    - `provider-A --model foo -- --help` → model="foo", remaining=["provider-A", "--", "--help"]
+    - Both flags: `provider-A --model foo --small-fast-model bar -- cmd` → both extracted
+    - `--model` without value → error
+    - `--small-fast-model` without value → error
+    - `--model` after `--` separator → NOT extracted (forwarded arg)
+    - No provider with flag: `--model foo` → model="foo", remaining=[]
+    - Flag value is `-`: `provider-A --model -` → model="-", remaining=["provider-A"]
+    - Duplicate flags: `provider-A --model foo --model bar` → model="bar", remaining=["provider-A"]
+  - [x] Table-driven tests for `WantsHelp` in `args_test.go` covering:
+    - `["--help"]` → true
+    - `["-h"]` → true
+    - `["provider-A", "--", "--help"]` → false (after separator)
+    - `[]` → false
+    - `["provider-A", "--help"]` → true
+    - `["provider-A"]` → false
+  - [x] Verify tests fail to compile (ExtractFlags and WantsHelp don't exist yet)
+
+- [x] Task 2: GREEN — implement ExtractFlags in internal/runner/args.go (AC: #8)
+  - [x] Write `ExtractFlags(args []string) (model, smallFastModel string, remaining []string, err error)` in `args.go`
+  - [x] Logic: find `--` separator, scan only args before it for `--model <value>` and `--small-fast-model <value>` pairs, remove matched pairs, return remaining args + flag values
+  - [x] Error cases: `--model` without value → `"--model requires a value"`, same for `--small-fast-model`
+  - [x] Error returns use `[]string{}` (not `nil`) for remaining slice
+  - [x] Keep ParseArgs unchanged — its flag rejection catches unknown flags after extraction
+  - [x] Verify Task 1 tests now pass
+
+- [x] Task 3: RED — write failing tests for buildEnv priority chain in runner_test.go (AC: #1-#5, #10)
+  - [x] Table-driven tests in `runner_test.go` covering:
+    - opts.Model set, ctx.Model empty → uses opts.Model
+    - opts.Model set, ctx.Model set → opts.Model wins
+    - opts.Model empty, ctx.Model set → uses ctx.Model
+    - Both empty → no ANTHROPIC_MODEL injected
+    - Same 4 cases for SmallFastModel
+    - Mixed case: opts.Model set, ctx.SmallFastModel set → correct priority for each
+  - [x] Verify tests fail (buildEnv doesn't check opts.Model yet)
+
+- [x] Task 4: GREEN — implement priority chain in runner.go:buildEnv (AC: #1-#5)
+  - [x] Change model logic: `opts.Model > ctx.Model > omit` pattern
+  - [x] Same pattern for SmallFastModel
+  - [x] Verify Task 3 tests now pass
+
+- [x] Task 5: RED — update breaking test + write failing integration tests for run command flags (AC: #6, #7, #10)
+  - [x] Update existing test "ParseArgs error - flag-like arg" in `cmd/run_test.go`: change args from `[]string{"--model", "foo"}` to `[]string{"--unknown-flag", "foo"}` (since `--model` is now extracted by ExtractFlags instead of rejected by ParseArgs)
+  - [x] Add table-driven tests in `cmd/run_test.go` covering:
+    - `--model foo provider-A` with env-capturing claude mock → success, verify ANTHROPIC_MODEL env var (see "Env-Capturing Mock Pattern" in Dev Notes)
+    - `--model foo provider-A -- --help` → args forwarded correctly, verify success
+    - `--model` without value → exit code 1
+    - Both flags: `provider-A --model foo --small-fast-model bar` → success, verify both env vars
+  - [x] Verify new tests fail (runRun doesn't call ExtractFlags yet)
+
+- [x] Task 6: RED — write failing integration tests for exec command flags in cmd/exec_test.go (AC: #6, #10)
+  - [x] Create new file `cmd/exec_test.go` (package cmd, like run_test.go)
+  - [x] Table-driven tests covering:
+    - `--model foo provider-A` with env-capturing shell mock → success, verify ANTHROPIC_MODEL env var (see "Env-Capturing Mock Pattern" in Dev Notes; mock named as `$SHELL` basename, e.g. `bash`)
+    - `--model` without value → exit code 1
+    - `provider-A --model foo -- env | grep MODEL` → success with model override. Mock named `env` (first target arg after `--`), not `$SHELL` basename.
+  - [x] Verify tests fail (execRun doesn't call ExtractFlags yet)
+
+- [x] Task 7: GREEN — update cmd/run.go and cmd/exec.go to use ExtractFlags (AC: #6, #7, #9)
+  - [x] Set `DisableFlagParsing: true` on RunCmd and ExecCmd
+  - [x] Add `runner.WantsHelp(args)` check in Run closures before calling runRun/execRun — if true, call `cmd.Help()` and return (prevents `--help` regression from DisableFlagParsing)
+  - [x] In `runRun()` and `execRun()`, call `runner.ExtractFlags(args)` before `runner.ParseArgs()`
+  - [x] Pass `model` and `smallFastModel` into `runner.Options{...}`
+  - [x] Error handling: print extraction error to stderr, return 1
+  - [x] Verify Tasks 5-6 tests now pass
+
+- [x] Task 8: Verify all tests and build (AC: #9)
+  - [x] `go test ./...` passes
+  - [x] `go vet ./...` clean
+  - [x] `make build` succeeds
+  - [ ] Manual smoke test: `ccctx run <provider> --model <model-name>`
+  - [ ] Manual smoke test: `ccctx run --help` shows help (not error)
+  - [ ] Manual smoke test: `ccctx exec --help` shows help (not error)
+
+## Dev Notes
+
+### Critical Design Decision: Flag Parsing vs -- Separator
+
+The architecture doc explicitly warns: registering `--model` as a Cobra flag causes Cobra to consume the `--` separator, breaking `ParseArgs`. **Resolution: set `DisableFlagParsing: true` on both commands and parse flags manually.**
+
+This means:
+- Cobra passes raw args to our `Run` function (no flag processing)
+- We call `runner.ExtractFlags(args)` to extract `--model` and `--small-fast-model` from args before `--`
+- We pass remaining args to `runner.ParseArgs()` (unchanged)
+- ParseArgs' existing flag rejection still catches unknown flags (e.g., `--unknown-flag`)
+
+### Flag Extraction Algorithm
+
+`ExtractFlags` scans args before the `--` separator for known flag-value pairs. After extraction, remaining args should contain at most one non-flag arg (the provider name) before `--`.
+
+```go
+func ExtractFlags(args []string) (model, smallFastModel string, remaining []string, err error) {
+    sepIdx := len(args) // scan all args by default
+    for i, a := range args {
+        if a == "--" {
+            sepIdx = i
+            break
+        }
+    }
+
+    // Build remaining by scanning pre-separator args
+    remaining = make([]string, 0, len(args))
+    preSep := args[:sepIdx]
+    i := 0
+    for i < len(preSep) {
+        switch preSep[i] {
+        case "--model":
+            if i+1 >= len(preSep) {
+                return "", "", []string{}, fmt.Errorf("--model requires a value")
+            }
+            model = preSep[i+1]
+            i += 2
+        case "--small-fast-model":
+            if i+1 >= len(preSep) {
+                return "", "", []string{}, fmt.Errorf("--small-fast-model requires a value")
+            }
+            smallFastModel = preSep[i+1]
+            i += 2
+        default:
+            remaining = append(remaining, preSep[i])
+            i++
+        }
+    }
+
+    // Append separator and post-separator args unchanged
+    if sepIdx < len(args) {
+        remaining = append(remaining, args[sepIdx:]...)
+    }
+
+    return model, smallFastModel, remaining, nil
+}
+```
+
+### Help Handling (prevents --help regression)
+
+With `DisableFlagParsing: true`, Cobra no longer processes `--help`. Add a `WantsHelp` helper in `args.go` and check it in the Run closures before calling runRun/execRun:
+
+```go
+// WantsHelp checks if --help or -h appears before -- in args.
+func WantsHelp(args []string) bool {
+    for _, a := range args {
+        if a == "--" {
+            break
+        }
+        if a == "--help" || a == "-h" {
+            return true
+        }
+    }
+    return false
+}
+```
+
+Note: `ccctx --help run` and `ccctx help run` still work (parent command handles them).
+
+### Command File Changes
+
+**cmd/run.go** (minimal diff):
+
+```go
+var RunCmd = &cobra.Command{
+    Use:              "run [context] [-- claude-args...]",
+    Short:            "Run claude with a context",
+    Long:             "...",
+    Args:             cobra.ArbitraryArgs,
+    DisableFlagParsing: true,  // ADD THIS
+    Run: func(cmd *cobra.Command, args []string) {
+        if runner.WantsHelp(args) {  // ADD: handle --help before DisableFlagParsing
+            cmd.Help()
+            return
+        }
+        os.Exit(runRun(args))
+    },
+}
+
+func runRun(args []string) int {
+    // ADD: extract flags before ParseArgs
+    model, smallFastModel, args, err := runner.ExtractFlags(args)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+        return 1
+    }
+
+    provider, targetArgs, useTUI, err := runner.ParseArgs(args)
+    // ... (TUI flow unchanged) ...
+
+    r, err := runner.New(runner.Options{
+        ContextName:    provider,
+        Target:         target,
+        Model:          model,          // ADD
+        SmallFastModel: smallFastModel, // ADD
+    })
+    // ... (rest unchanged) ...
+}
+```
+
+**cmd/exec.go**: identical pattern — add `DisableFlagParsing: true`, add `WantsHelp` check in Run closure, call `ExtractFlags` at top of `execRun`, pass flags in Options.
+
+### buildEnv Priority Chain
+
+Current `buildEnv` in `runner.go:82-99` uses `ctx.Model` directly. Change to:
+
+```go
+func buildEnv(ctx *config.Context, opts Options) []string {
+    // ... filtering unchanged ...
+
+    filtered = append(filtered, "ANTHROPIC_BASE_URL="+ctx.BaseURL)
+    filtered = append(filtered, "ANTHROPIC_AUTH_TOKEN="+ctx.AuthToken)
+
+    // Priority: CLI flag > config value > omit
+    model := opts.Model
+    if model == "" {
+        model = ctx.Model
+    }
+    if model != "" {
+        filtered = append(filtered, "ANTHROPIC_MODEL="+model)
+    }
+
+    sfm := opts.SmallFastModel
+    if sfm == "" {
+        sfm = ctx.SmallFastModel
+    }
+    if sfm != "" {
+        filtered = append(filtered, "ANTHROPIC_SMALL_FAST_MODEL="+sfm)
+    }
+
+    return filtered
+}
+```
+
+This is a minimal change — only the model/small_fast_model injection logic changes. The existing injection order (BASE_URL → AUTH_TOKEN → MODEL → SMALL_FAST_MODEL) is preserved.
+
+### Key Files
+
+| File | Role | Change Type |
+|------|------|-------------|
+| `internal/runner/args.go` | ParseArgs, ExtractFlags, WantsHelp | MODIFY — add ExtractFlags and WantsHelp functions |
+| `internal/runner/runner.go` | buildEnv | MODIFY — implement priority chain |
+| `cmd/run.go` | run command | MODIFY — add DisableFlagParsing, WantsHelp check, ExtractFlags call, pass flags |
+| `cmd/exec.go` | exec command | MODIFY — same as run.go |
+| `internal/runner/args_test.go` | Tests for ExtractFlags | MODIFY — add test cases |
+| `internal/runner/runner_test.go` | Tests for buildEnv priority | MODIFY — add test cases |
+| `cmd/run_test.go` | Integration tests | MODIFY — update breaking test, add flag test cases |
+| `cmd/exec_test.go` | Integration tests for exec | CREATE — new file for exec flag tests |
+
+### Env-Capturing Mock Pattern
+
+Integration tests need to verify that `ANTHROPIC_MODEL` (and optionally `ANTHROPIC_SMALL_FAST_MODEL`) are set in the child process environment. The existing mocks (`exit 0` / `exit 42`) don't capture env vars. Use this pattern:
+
+**Mock script** (writes env vars to a file for assertion):
+```sh
+#!/bin/sh
+echo "$ANTHROPIC_MODEL" > "$MOCK_OUTPUT_FILE"
+echo "$ANTHROPIC_SMALL_FAST_MODEL" >> "$MOCK_OUTPUT_FILE"
+exit 0
+```
+
+**Test setup**:
+1. Create temp file for mock output: `outputFile := filepath.Join(t.TempDir(), "mock_output")`
+2. Create mock script that writes to `$MOCK_OUTPUT_FILE`
+3. Set `MOCK_OUTPUT_FILE` env var in test: `t.Setenv("MOCK_OUTPUT_FILE", outputFile)`
+4. Set `PATH` to temp dir containing the mock. Mock naming rules:
+   - **run tests**: mock named `claude` (runRun calls `exec.LookPath("claude")`)
+   - **exec tests with no target args**: mock named as `$SHELL` basename (e.g., `bash`) — exec falls back to `$SHELL`. **Important:** must also set `SHELL` env var to mock's full path: `t.Setenv("SHELL", filepath.Join(tmpDir, "bash"))`. Without this, `os.Getenv("SHELL")` returns the real shell path (e.g., `/bin/bash`) and `exec.Command` runs the real shell instead of the mock.
+   - **exec tests with explicit target args after `--`**: mock named after the first target arg (e.g., `env` for `-- env | grep MODEL`)
+5. After `runRun(args)` returns, read `outputFile` and assert contents
+
+This approach avoids modifying the runner or cmd code — the env var propagation is tested end-to-end through the actual `exec.LookPath` → `exec.Cmd.Env` → child process path.
+
+### Previous Story Intelligence
+
+From Story 3-1 implementation:
+- `ParseArgs` now rejects flag-like args in provider position — this is the **critical prerequisite** that allows us to catch unknown flags after our extraction
+- `cmd/run.go` and `cmd/exec.go` both use `runRun(args) int` / `execRun(args) int` pattern — `os.Exit()` only at top level
+- `Options` struct already has `Model` and `SmallFastModel` fields — we just need to populate them
+- `buildEnv` already receives `opts Options` — we just need to check `opts.Model` before `ctx.Model`
+- `cmd/run_test.go` uses `package cmd` (not `cmd_test`) to access unexported `runRun`
+
+From Story 2-2 implementation:
+- TUI uses sentinel error `ErrCancelled` — checked via `errors.Is(err, ui.ErrCancelled)`
+- All error output uses `fmt.Fprintf(os.Stderr, ...)` or `fmt.Fprintln(os.Stderr, ...)`
+
+From Story 1-3 implementation:
+- Runner struct carries `ctx`, `opts`, `env`
+- `buildEnv` signature: `buildEnv(ctx *config.Context, opts Options) []string`
+- Both commands follow identical error handling pattern
+
+### Anti-Patterns (Do NOT)
+
+- Do NOT register `--model` as a Cobra flag — it will consume the `--` separator
+- Do NOT modify `ParseArgs` — keep its flag rejection for unknown flags
+- Do NOT extract flags from after the `--` separator — those are forwarded args
+- Do NOT call `os.Exit()` inside `internal/runner/` — breaks testability
+- Do NOT use `fmt.Fprintf(os.Stderr, ...)` inside runner — commands own output
+- Do NOT change the buildEnv injection order — BASE_URL → AUTH_TOKEN → MODEL → SMALL_FAST_MODEL
+- Do NOT inject empty model values — check `!= ""` before appending
+- Do NOT duplicate the flag extraction logic between run.go and exec.go — use shared `ExtractFlags` in runner package
+- Do NOT add `-m` or other shorthand flags — only `--model` and `--small-fast-model` as specified
+- Do NOT modify `config/config.go` or `internal/ui/selector.go` — not in scope
+
+### Project Structure Notes
+
+- All changes in existing packages (`internal/runner/`, `cmd/`)
+- `ExtractFlags` and `WantsHelp` go in `args.go` alongside `ParseArgs` — all are argument processing functions
+- `DisableFlagParsing: true` is a Cobra feature that prevents any flag processing, giving us raw args
+- No new dependencies needed
+- All Go source files use tab indentation — run `go fmt` after edits. Code snippets in this plan use spaces for readability only.
+
+### Edge Cases to Handle
+
+1. **Flag after --**: `ccctx run provider-A -- --model foo` → `--model foo` is forwarded to claude, NOT extracted. ExtractFlags only scans before `--`.
+2. **No provider with flag**: `ccctx run --model foo` → TUI mode with model override. After extraction, remaining args are empty → useTUI=true.
+3. **Flag value starts with dash**: `ccctx run provider-A --model -` → model value is `-`. This is technically valid (though unusual). ExtractFlags should accept it.
+4. **Duplicate flags**: `ccctx run provider-A --model foo --model bar` → last value wins (second overwrites first in sequential scan).
+5. **Flag before provider**: `ccctx run --model foo provider-A` → works, ExtractFlags reorders to extract flag, leaving `provider-A` in remaining.
+6. **--help before separator**: `ccctx run --help` → WantsHelp returns true, shows Cobra help. `ccctx run provider-A -- --help` → `--help` after `--` is forwarded, not intercepted.
+7. **Unknown flag**: `ccctx run --unknown-flag foo` → not extracted by ExtractFlags, passed to ParseArgs, rejected as flag-like arg (existing behavior).
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 3.2] — story definition and AC
+- [Source: _bmad-output/planning-artifacts/architecture.md#Phase 2] — known --model vs -- conflict, model priority chain
+- [Source: _bmad-output/planning-artifacts/architecture.md#AD1] — Runner struct design with Model/SmallFastModel fields
+- [Source: _bmad-output/planning-artifacts/prd.md#FR27-FR28] — functional requirements for model override
+- [Source: internal/runner/runner.go:82-99] — buildEnv, current model injection logic
+- [Source: internal/runner/runner.go:14-19] — Options struct with Model/SmallFastModel fields
+- [Source: internal/runner/args.go:28-29,40-41] — flag rejection in ParseArgs (prerequisite from Story 3.1)
+- [Source: cmd/run.go:15-23] — RunCmd definition, needs DisableFlagParsing
+- [Source: cmd/exec.go:14-22] — ExecCmd definition, needs DisableFlagParsing
+- [Source: cmd/run.go:25-78] — runRun function, needs ExtractFlags call
+- [Source: cmd/exec.go:24-74] — execRun function, needs ExtractFlags call
+- [Source: _bmad-output/implementation-artifacts/3-1-runner-and-command-layer-robustness.md] — previous story learnings
+- [Source: _bmad-output/project-context.md] — implementation rules and patterns
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude (glm-5.1)
+
+### Debug Log References
+
+### Completion Notes List
+
+- Implemented `ExtractFlags` in `internal/runner/args.go` — extracts `--model` and `--small-fast-model` from args before `--` separator, handles all edge cases (flag after separator, missing value, duplicate flags, dash value)
+- Implemented `WantsHelp` in `internal/runner/args.go` — checks for `--help`/`-h` before `--` separator, prevents regression from `DisableFlagParsing: true`
+- Updated `buildEnv` in `internal/runner/runner.go` — priority chain `opts.Model > ctx.Model > omit` for both Model and SmallFastModel
+- Updated `cmd/run.go` — added `DisableFlagParsing: true`, `WantsHelp` check, `ExtractFlags` call, passes model flags in Options
+- Updated `cmd/exec.go` — identical pattern as run.go
+- Updated `cmd/run_test.go` — changed breaking test from `--model` to `--unknown-flag`, added `TestRunRun_ModelFlags` with env-capturing mock pattern
+- Created `cmd/exec_test.go` — new file with `TestExecRun_ModelFlags` using env-capturing mocks for shell and explicit target scenarios
+
+### File List
+
+- `internal/runner/args.go` — modified: added `ExtractFlags` and `WantsHelp` functions
+- `internal/runner/args_test.go` — modified: added `TestExtractFlags` and `TestWantsHelp` table-driven tests
+- `internal/runner/runner.go` — modified: updated `buildEnv` with priority chain for Model and SmallFastModel
+- `internal/runner/runner_test.go` — modified: added `TestBuildEnv_PriorityChain` table-driven tests
+- `cmd/run.go` — modified: added `DisableFlagParsing`, `WantsHelp` check, `ExtractFlags` call, model flags in Options
+- `cmd/exec.go` — modified: same changes as run.go
+- `cmd/run_test.go` — modified: updated breaking test args, added `TestRunRun_ModelFlags` integration tests
+- `cmd/exec_test.go` — created: new file with `TestExecRun_ModelFlags` integration tests
+
+### Review Findings
+
+- [x] [Review][Patch] `run_test.go` 缺少 `--small-fast-model` 无值错误测试，`exec_test.go` 完全缺少 `--small-fast-model` 覆盖 [cmd/run_test.go, cmd/exec_test.go] — 已添加测试
+- [x] [Review][Patch] 标志值看起来像另一个标志时（如 `--model --small-fast-model`）被误解析为值，缺少测试 [internal/runner/args.go:24-39] — 已添加测试记录此行为（规范允许 `--model -`，故不添加拒绝逻辑）
+- [x] [Review][Patch] 缺少重复 `--small-fast-model` 标志测试（规范要求 last wins）[internal/runner/args_test.go] — 已添加测试
+- [x] [Review][Patch] 缺少组合标志行为测试 [internal/runner/args_test.go] — 已添加测试
+- [x] [Review][Patch] `ExtractFlags` 错误消息格式不一致（句子大小写 vs `ParseArgs` 小写）[internal/runner/args.go] — 经核实，错误消息已一致（均为小写开头），无需修改
+- [x] [Review][Patch] `buildEnv` 缺少 `opts > ctx` 优先级规则的代码注释 [internal/runner/runner.go:93-107] — 已添加注释
+- [x] [Review][Patch] 缺少 `--` 分隔符后无参数的测试（如 `--model foo --`）[internal/runner/args_test.go] — 已添加测试
+- [x] [Review][Patch] `cmd.Help()` 错误被静默吞掉，未处理 [cmd/run.go:22-25, cmd/exec.go:21-24] — 已添加错误处理
+- [x] [Review][Patch] model/SFM 值可能包含换行，导致环境变量注入 [internal/runner/runner.go:93-107] — 已在 `ExtractFlags` 中添加换行符验证（CLI 输入路径）；配置值路径已在 Story 3.1 中标记为 deferred
+- [x] [Review][Patch] 测试输出文件读取逻辑在 wantSFM 为空时不会验证第二行不存在 [cmd/run_test.go:216-225, cmd/exec_test.go:99-108] — 已改用 `require` 断言，确保预期值存在时才验证
+- [x] [Review][Defer] `claude` 二进制存在但不可执行时，`exec.LookPath` 成功但 `exec.Command` 会失败 [cmd/run.go:66-70] — deferred, pre-existing
+- [x] [Review][Defer] `SHELL` 环境变量设为空字符串时会被当作目标命令传递 [cmd/exec.go:63-70] — deferred, pre-existing

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -42,3 +42,13 @@
 - ~~缺少对新增代码路径的测试 [internal/ui/selector_test.go]~~ — promoted to Story 4.2
 - ~~空字符串上下文名被误认为取消 [internal/ui/selector.go]~~ — promoted to Story 4.2
 - ~~flexHeightPadding 值与实际 tview 布局无验证 [internal/ui/selector.go:25]~~ — promoted to Story 4.2
+
+## Deferred from: code review of 3-1-runner-and-command-layer-robustness (2026-04-23)
+
+- 跨平台兼容性：Windows 上假 claude 脚本使用 shebang 不工作 [cmd/run_test.go]
+- buildEnv 不验证注入环境变量值中的换行或空字节 [internal/runner/runner.go:82-99]
+- config 对 base_url 不支持 env: 前缀解析（与 auth_token 不一致）[config/config.go]
+- SHELL 环境变量可执行性未验证 [cmd/exec.go:52-58]
+- 目标命令被信号终止时退出码丢失 [internal/runner/runner.go:64-80]
+- 空 provider 名未在 ParseArgs 中显式拒绝 [internal/runner/args.go]
+- 通用 "Error: %v" 消息模式不利于程序化错误区分 [cmd/run.go, cmd/exec.go]

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -52,3 +52,8 @@
 - 目标命令被信号终止时退出码丢失 [internal/runner/runner.go:64-80]
 - 空 provider 名未在 ParseArgs 中显式拒绝 [internal/runner/args.go]
 - 通用 "Error: %v" 消息模式不利于程序化错误区分 [cmd/run.go, cmd/exec.go]
+
+## Deferred from: code review of 3-2-add-model-override-flags-to-run-and-exec (2026-04-23)
+
+- `claude` 二进制存在但不可执行时，`exec.LookPath` 成功但 `exec.Command` 会失败 [cmd/run.go:66-70]
+- `SHELL` 环境变量设为空字符串时会被当作目标命令传递 [cmd/exec.go:63-70]

--- a/_bmad-output/implementation-artifacts/epic-3-retro-2026-05-13.md
+++ b/_bmad-output/implementation-artifacts/epic-3-retro-2026-05-13.md
@@ -1,0 +1,143 @@
+# Epic 3 Retrospective: Model Override Flags (Phase 2)
+
+**Date:** 2026-05-13
+**Participants:** Amelia (Developer), Alice (Product Owner), Charlie (Senior Dev), Dana (QA Engineer), dsdashun (Project Lead)
+
+## Epic Summary
+
+- **Completed:** 2/2 stories (100%)
+- **Stories:** 3-1 (Runner & Command Layer Robustness) + 3-2 (Add --model Override Flags)
+- **Plan Review rounds:** 3 per story (6 total)
+- **User Story Test rounds:** 3-1 (1 round), 3-2 (2 rounds)
+- **Review patches:** 3-1 (2), 3-2 (10+)
+- **Deferred items digested:** 5 (absorbed into Story 3-1 AC)
+- **Deferred items added:** 9 (from Epic 3 code reviews)
+- **Production incidents:** 0
+- **FRs satisfied:** FR27, FR28 — all 28 FRs now complete
+
+## Successes
+
+1. **Technical debt digestion started** — Story 3-1 explicitly absorbed 5 deferred items from previous code reviews. "First repay debt, then build" strategy proved effective: Story 3-2 was built on a solid foundation.
+
+2. **DisableFlagParsing + ExtractFlags + WantsHelp pattern** — Clean solution to the Cobra `--` separator conflict documented since architecture phase. No hacks, no workarounds. Manual flag extraction before ParseArgs, with help handling to prevent regression.
+
+3. **Env-capturing mock pattern invented** — Previous tests only verified exit codes (mock scripts that `exit 0`). New pattern writes `ANTHROPIC_MODEL` to a temp file for assertion, enabling true end-to-end verification of environment variable propagation through `ExtractFlags → Options → buildEnv → exec.Command.Env`. Reusable for future tests.
+
+4. **Dual review process continued delivering value** — Both stories underwent Plan Review + User Story Test. TDD violations caught in both stories at BLOCKING severity. `--help` regression from `DisableFlagParsing` caught proactively. All team agreements from Epic 2 retro honored.
+
+5. **All 28 functional requirements satisfied** — Project's core product vision is complete.
+
+## Challenges
+
+1. **TDD ordering violated in both stories** — Story 3-1 and 3-2 both had implementation tasks before test tasks in initial plans. Same mistake, two stories in a row. Caught by Plan Review both times, but indicates a systematic habit issue in planning phase, not an occasional oversight.
+
+2. **Deferred items net growth** — Digested 5, added 9, net +4. Some Epic 3 deferred items (LookPath executability, SHELL validation, signal termination exit codes) fall outside Epic 4 scope, with no clear digestion path yet.
+
+3. **`--help` regression was subtle** — Disabling Cobra flag parsing silently disabled `--help`. Not a visible code change — an architectural side effect. Only caught because Plan Review thought to trace the impact of `DisableFlagParsing: true`.
+
+## Key Insights
+
+1. **"Repay debt in the same files" is the right strategy** — Not a dedicated tech-debt epic, but absorbing deferred items into stories that touch the same files. Efficient and contextual.
+
+2. **Plan Review is an effective safety net, not a replacement for good planning habits** — TDD ordering was caught both times, but the goal should be needing review less, not relying on it more.
+
+3. **Architectural decisions have hidden side effects** — `DisableFlagParsing` solved the `--` conflict but silently broke `--help`. When making architectural changes, trace all behaviors that depend on the changed component.
+
+4. **Claude Code environment variables are evolving** — `ANTHROPIC_SMALL_FAST_MODEL` is deprecated in favor of `ANTHROPIC_DEFAULT_HAIKU_MODEL`. New variables (`ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`) need support. This affects PRD, architecture, config format, and CLI flags.
+
+## Previous Retro Follow-Through
+
+### Action Items from Epic 2
+
+| # | Action Item | Owner | Status |
+|---|------------|-------|--------|
+| 1 | Institutionalize dual review process | dsdashun + Amelia | ✅ Completed — both stories had 3-round Plan Review + User Story Test |
+| 2 | Deferred item digestion in sprint planning | Amelia | ✅ Completed — Story 3-1 explicitly absorbed 5 deferred items |
+
+### Team Agreements from Epic 2
+
+| # | Agreement | Status |
+|---|-----------|--------|
+| 1 | Brownfield first story acknowledged as naturally heavy | ✅ Honored |
+| 2 | Automated tests written alongside refactoring | ✅ Honored — cmd/run_test.go, cmd/exec_test.go created |
+| 3 | Every story undergoes Plan Review + User Story Review | ✅ Honored |
+| 4 | Sprint planning scans deferred-work.md | ✅ Honored — Story 3-1 absorbed 5 items |
+| 5 | Fix deferred items in same file when making changes | ✅ Honored — Story 3-1 fixed items in runner and cmd files |
+
+### Technical Debt from Epic 2
+
+| # | Debt Item | Status |
+|---|-----------|--------|
+| 1 | cmd/*.go error handling duplication | ⏳ Absorbed into Story 3-1 and resolved |
+| 2 | runner.Run double-prints non-ExitError failures | ⏳ Absorbed into Story 3-1 and resolved |
+
+## Significant Discovery
+
+**Claude Code environment variables are outdated:**
+- `ANTHROPIC_SMALL_FAST_MODEL` is deprecated, replaced by `ANTHROPIC_DEFAULT_HAIKU_MODEL`
+- New variables needed: `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`
+- **Decisions made:**
+  - New and old variables coexist
+  - `small_fast_model` config field preserved for forward compatibility
+  - `--small-fast-model` CLI flag becomes alias for `--haiku-model`
+  - `--model` flag unchanged
+- **Impact:** PRD update required (FR2, FR27-FR28, possible new FRs), architecture update needed, Epic 4 scope and priority changes
+- **Recommended action:** `/bmad-correct-course`
+
+## Action Items
+
+### Process Improvements
+
+1. **Plan with TDD ordering by default** — Structure tasks as RED→GREEN→REFACTOR in initial plans, reduce reliance on Plan Review to catch ordering
+   - Owner: Amelia
+   - Success criteria: Next story's initial plan follows RED-first ordering
+
+### Technical Debt
+
+2. **Track out-of-scope deferred items** — LookPath executability, SHELL validation, signal exit codes are outside Epic 4 scope; ensure they don't get lost
+   - Owner: Charlie
+   - Priority: Medium
+
+### Course Correction
+
+3. **Run `/bmad-correct-course` for environment variable update** — Update PRD, adjust Epic 4 priority and scope
+   - Owner: dsdashun
+   - Priority: High (affects user-facing correctness)
+
+## Team Agreements
+
+- ✅ (carried forward) Dual review process (Plan Review + User Story Test) for every story
+- ✅ (carried forward) Sprint planning scans deferred-work.md
+- ✅ (carried forward) Fix deferred items in same file when making changes
+- 🆕 **Plan with TDD ordering by default (RED→GREEN→REFACTOR), reduce reliance on review interception**
+
+## Next Epic Preparation
+
+**Pending `/bmad-correct-course` — current Epic 4 definition may change.**
+
+Original Epic 4 (Tech Debt & Code Quality):
+- Story 4-1: Config Loading Robustness
+- Story 4-2: TUI Selector Quality Polish
+
+Likely new priority: Environment variable update (ANTHROPIC_DEFAULT_*_MODEL support)
+
+## Readiness Assessment
+
+- Testing & Quality: ✅ All tests pass, vet clean, build succeeds
+- Deployment: N/A (CLI tool, user builds locally)
+- Stakeholder Acceptance: N/A (single developer project)
+- Codebase Health: ✅ Stable and maintainable; 9 new deferred items tracked
+- Unresolved Blockers: None — Epic 4 can start after `/bmad-correct-course`
+
+## Commitments
+
+- Action Items: 3
+- Team Agreements: 4 (3 carried forward + 1 new)
+- Critical Path Items: 1 (`/bmad-correct-course`)
+
+## Next Steps
+
+1. Run `/bmad-correct-course` to handle environment variable update
+2. Update PRD with new/revised functional requirements
+3. Update architecture with new env var injection logic and config field design
+4. Re-plan Epic 4 based on correct-course outcome

--- a/_bmad-output/implementation-artifacts/reviews/3-1-runner-and-command-layer-robustness-review.md
+++ b/_bmad-output/implementation-artifacts/reviews/3-1-runner-and-command-layer-robustness-review.md
@@ -1,0 +1,288 @@
+---
+reviewed_plan: _bmad-output/implementation-artifacts/3-1-runner-and-command-layer-robustness.md
+reviewer: kimi
+latest_round: 3
+review_rounds:
+  - round: 1
+    date: 2026-04-20
+  - round: 2
+    date: 2026-04-20
+  - round: 3
+    date: 2026-04-20
+---
+
+# Review: 3-1-runner-and-command-layer-robustness
+
+Reviewed plan: `_bmad-output/implementation-artifacts/3-1-runner-and-command-layer-robustness.md`
+
+## Round 1
+
+**Context:** Initial full dry-run of the plan against the actual codebase.
+
+### Issues Found
+
+#### 1. [BLOCKING] Task 1 and Task 3 violate TDD: implementation before tests
+
+- **Plan says (Task 1):** Subtask order: (a) import `net/url`, (b) add `validateURL` helper, (c) call it in `New()`, (d) add table-driven tests in `runner_test.go`.
+- **Actual:** This is the "test-after" anti-pattern. Tests are written after the implementation is complete, so they will pass immediately and never prove they can catch real bugs.
+- **Impact:** If the `validateURL` implementation has edge-case bugs (e.g., `url.Parse` accepting `://example.com` as valid with empty scheme but non-empty opaque part), the tests written afterward may simply encode those same bugs. The tests provide no regression safety.
+- **Suggested fix:** Restructure Task 1 into Red-Green-Refactor:
+  - **RED:** Write table-driven tests in `runner_test.go` first that call a non-existent `validateURL` (or call `New()` with invalid URLs). Run tests, confirm failures.
+  - **GREEN:** Implement `validateURL` and wire it into `New()`.
+  - **REFACTOR:** Clean up if needed.
+
+- **Plan says (Task 3):** Subtask order: (a) modify `ParseArgs` to reject flag-like args, (b) add test cases in `args_test.go`.
+- **Actual:** Same anti-pattern. `args_test.go` tests are added after the behavior change.
+- **Impact:** New test cases like `["--model", "foo"]` and `["-m"]` will pass immediately because the implementation is already written. If the `ParseArgs` logic incorrectly handles edge cases (e.g., `["-", "--", "cmd"]` where `-` is a single-dash non-flag), tests will encode the bug.
+- **Suggested fix:** Restructure Task 3:
+  - **RED:** Add failing test cases in `args_test.go` for flag-like args: `["--model", "foo"]`, `["-m"]`, `["--model", "--", "foo"]`.
+  - **GREEN:** Modify `ParseArgs` to reject providers starting with `-`.
+  - **REFACTOR:** Ensure error message consistency.
+
+#### 2. [HIGH] Task 5 "TUI cancel (ErrCancelled)" test case is not feasible with current architecture
+
+- **Plan says:** Test cases include "TUI cancel (ErrCancelled)" in `cmd/run_test.go`, testing `runRun` directly.
+- **Actual:** When `useTUI` is true, `runRun` calls `ui.RunContextSelector(contexts)`, which internally creates a `tview.Application` and calls `app.Run()`. This requires an interactive terminal and cannot run in a `go test` environment. There is no dependency-injection point to mock the selector.
+- **Impact:** The executor will attempt to write this test, discover it hangs or fails in CI, and either (a) skip it, leaving a gap in coverage, or (b) spend significant time trying to make it work. Either way, the plan's stated test coverage is unachievable as written.
+- **Suggested fix:** Either:
+  - **Option A (recommended):** Add a `selectorFunc` parameter to `runRun` (e.g., `runRun(args []string, selectContext func([]string) (string, error)) int`), and pass `ui.RunContextSelector` from the command's `Run` closure. In tests, inject a mock that returns `ui.ErrCancelled`.
+  - **Option B:** Explicitly exclude the TUI cancel path from `cmd/run_test.go` scope, and add a comment documenting the untested path. Rely on manual smoke testing (Task 6) for TUI coverage.
+
+#### 3. [MEDIUM] Task 3 description of flag detection is ambiguous
+
+- **Plan says:** "In `ParseArgs`, when the first arg before `--` starts with `-`, return an error."
+- **Actual:** When there is no `--` separator (e.g., `["--model", "foo"]`), the concept of "before `--`" does not exist. The current `ParseArgs` has two code paths: (1) `--` present, (2) `--` absent. The plan's wording conflates both paths under a single imprecise description. The intended behavior is clear from the test cases (reject `args[0]` starting with `-` in the no-separator path, and reject `contextArgs[0]` starting with `-` in the separator path), but a literal reading of the step could lead to inconsistent implementations.
+- **Impact:** Different executors may implement the check in different places within `ParseArgs`, leading to divergent behavior for edge cases like `["--model", "--", "foo"]` vs `["--model", "foo"]`.
+- **Suggested fix:** Clarify the Task 3 description:
+  > "In `ParseArgs`, when the resolved provider argument (the single argument before `--`, or `args[0]` when `--` is absent) starts with `-`, return an error: `flag-like argument '%s' not allowed in provider position`.
+
+#### 4. [LOW] Minor line number drift in Dev Notes references
+
+- **Plan says:** "Insert in `New()` between the `ctx.AuthToken == ""` check (line 36) and the `len(opts.Target) == 0` check (line 37)."
+- **Actual:** In the current `internal/runner/runner.go`, `ctx.AuthToken == ""` is at line 34, and `len(opts.Target) == 0` is at line 37. The content descriptions are correct, but the line numbers are off by two.
+- **Impact:** Minimal — the surrounding context (`ctx.AuthToken == ""` / `len(opts.Target) == 0`) makes the insertion point unambiguous.
+- **Suggested fix:** Update line references to `line 34` and `line 37`.
+
+#### 5. [LOW] `runner.go` `Run()` comment in Task 2 slightly mischaracterizes the contract
+
+- **Plan says (Task 2):** Add comment: `// Run executes the target command. Returns (exitCode, nil) for normal exits, (1, error) for start failures. Caller is responsible for printing errors.`
+- **Actual:** `Run()` returns `(exitErr.ExitCode(), nil)` for command exit errors (non-zero exit codes), not just "normal exits" (which implies exit code 0). The comment could mislead a reader into thinking `(exitCode, nil)` only happens on success.
+- **Impact:** A future maintainer might add redundant error handling for non-zero exit codes.
+- **Suggested fix:** Adjust the comment to: `// Run executes the target command. Returns (0, nil) on success, (exitCode, nil) for command exit errors, (1, error) for start failures. Caller is responsible for printing errors.`
+
+### Risk Summary
+
+| # | Severity | Issue | Task |
+|---|----------|-------|------|
+| 1 | **BLOCKING** | TDD violation: implementation before tests in Task 1 and Task 3 | Task 1, Task 3 |
+| 2 | HIGH | TUI cancel test not feasible without DI/mocking | Task 5 |
+| 3 | MEDIUM | Ambiguous flag detection description | Task 3 |
+| 4 | LOW | Line number drift in Dev Notes | Dev Notes |
+| 5 | LOW | `Run()` comment mischaracterizes non-zero exit path | Task 2 |
+
+### Verdict
+
+The plan is **NOT ready for execution**. Fix the **blocking issue (#1)** — restructure Tasks 1 and 3 to follow Red-Green-Refactor (write failing tests first, then implementation). Also address the **high-severity issue (#2)** by either introducing dependency injection for the TUI selector or explicitly excluding the TUI cancel path from unit test scope. Issues #3, #4, and #5 should also be addressed but are not hard blockers.
+
+## Round 1 Response
+
+**Responded by:** glm
+**Date:** 2026-04-20
+**Plan file:** 3-1-runner-and-command-layer-robustness.md (updated)
+
+### Issue Responses
+
+#### 1. [FIX] Task 1 and Task 3 violate TDD: implementation before tests
+
+**Change made:** Restructured both Task 1 and Task 3 into explicit Red-Green-Refactor subtasks. Task 1 now starts with "RED: Write table-driven tests first", then "GREEN: Implement validateURL", then "REFACTOR". Task 3 follows the same pattern with "RED: Add failing test cases", "GREEN: Modify ParseArgs", "REFACTOR".
+**Location:** Tasks 1 and 3 in the plan file
+
+#### 2. [FIX] TUI cancel (ErrCancelled) test case is not feasible with current architecture
+
+**Change made:** Removed "TUI cancel (ErrCancelled)" from Task 5's test cases. Added a note explaining why: `ui.RunContextSelector` requires an interactive terminal via `tview.Application.Run()`. The cancel path is covered by manual smoke testing in Task 6 instead. The `errors.Is(err, ui.ErrCancelled)` branch is a simple 3-line if-block with low risk. Chose Option B (exclude from unit test scope) over Option A (DI injection) to avoid adding unnecessary complexity for a trivial code path.
+**Location:** Task 5 test cases in the plan file
+
+#### 3. [FIX] Ambiguous flag detection description
+
+**Change made:** Updated Task 3 GREEN step and the Dev Notes "ParseArgs Flag Handling Strategy" section to use the clearer wording: "when the resolved provider argument (the single argument before `--`, or `args[0]` when `--` is absent) starts with `-`". This covers both code paths unambiguously.
+**Location:** Task 3 GREEN step and Dev Notes section
+
+#### 4. [FIX] Minor line number drift in Dev Notes references
+
+**Change made:** Updated line reference from "line 36" to "line 34" for the `ctx.AuthToken == ""` check.
+**Location:** Dev Notes — URL Validation Strategy
+
+#### 5. [FIX] `runner.go` `Run()` comment mischaracterizes the contract
+
+**Change made:** Updated the Task 2 comment from "Returns (exitCode, nil) for normal exits" to the three-case version: "Returns (0, nil) on success, (exitCode, nil) for command exit errors, (1, error) for start failures."
+**Location:** Task 2 comment in the plan file
+
+### Summary
+
+All 5 issues from Round 1 have been addressed. The plan is ready for re-review.
+
+---
+
+## Round 2
+
+**Context:** Plan was revised based on Round 1 feedback. All 5 issues were marked as fixed. This round re-verifies each fix against the actual codebase and checks for new issues introduced by the fixes or missed in Round 1.
+
+### Round 1 Issue Status
+
+| # | Severity | Issue | Round 2 Status |
+|---|----------|-------|----------------|
+| 1 | BLOCKING | TDD violation: implementation before tests in Task 1 and Task 3 | **FIXED** — Both tasks now follow explicit Red-Green-Refactor subtask ordering |
+| 2 | HIGH | TUI cancel test not feasible without DI/mocking | **FIXED** — TUI cancel removed from unit test scope; covered by Task 6 manual smoke test |
+| 3 | MEDIUM | Ambiguous flag detection description | **FIXED** — Task 3 GREEN and Dev Notes now use "resolved provider argument" wording covering both code paths |
+| 4 | LOW | Line number drift in Dev Notes | **FIXED** — Line reference updated to line 34 for `ctx.AuthToken == ""` check; verified against `internal/runner/runner.go` |
+| 5 | LOW | `Run()` comment mischaracterizes non-zero exit path | **FIXED** — Comment now correctly lists all three return patterns |
+
+### Issues Found
+
+#### 1. [MEDIUM] Task 1 RED doesn't explain config setup needed for `New()` URL validation tests
+
+- **Plan says (Task 1 RED):** "Write table-driven tests in `runner_test.go` first — test `validateURL` directly and test `New()` with invalid URLs. Cases: valid URL, missing scheme, contains spaces, empty string."
+- **Actual:** Testing `New()` with invalid URLs requires a config context with an invalid `BaseURL` to exist in the configuration store. `New()` calls `config.GetContext()`, which calls `LoadConfig()`, which reads from the file returned by `GetConfigPath()` (respecting `CCCTX_CONFIG_PATH`). Without setting up a temp config file and pointing `CCCTX_CONFIG_PATH` at it, calling `New()` with any context name will fail with "context not found" before reaching the URL validation code path.
+- **Impact:** The executor may write `New()` tests that fail for the wrong reason (context missing vs. URL invalid), or may spend time debugging why the URL validation test isn't exercising the intended code path.
+- **Suggested fix:** Add a note in Task 1 RED clarifying that `New()` tests require temp config setup:
+  > "For `New()` tests: create a temp TOML config file with contexts containing invalid `base_url` values, and use `t.Setenv(\"CCCTX_CONFIG_PATH\", tempFile)` before calling `New()`. Alternatively, focus RED tests on `validateURL` directly and defer `New()` integration tests to a separate test function."
+
+#### 2. [MEDIUM] Task 3 RED test cases lack expected error values
+
+- **Plan says (Task 3 RED):** "Add failing test cases in `args_test.go` for flag-like args in provider position: `["--model", "foo"]`, `["-m"]`, `["--model", "--", "foo"]`. Run tests, confirm failures."
+- **Actual:** The plan lists the input `args` for the failing test cases but does not specify what `wantErr` value each case should expect. The existing `args_test.go` uses a `wantErr string` field in the test table, so the executor must supply an expected error string to make the test complete and self-documenting.
+- **Impact:** Without a specified expected error, different executors may write tests expecting different messages (e.g., `"flag-like argument"` vs `"unexpected flag"`), leading to test-implementation mismatches during the GREEN phase.
+- **Suggested fix:** Specify the expected error string in the RED step. For example:
+  > "Expected error: `flag-like argument '--model' not allowed in provider position` (or similar — ensure the test expects a non-empty error containing the flag name)."
+
+#### 3. [LOW] Inconsistent error message between Task 3 GREEN and Dev Notes
+
+- **Plan says (Task 3 GREEN):** `return an error: "flag-like argument '%s' not allowed in provider position"`
+- **Plan says (Dev Notes — ParseArgs Flag Handling Strategy):** "return an error like `unexpected flag '--model' in provider position`"
+- **Actual:** These are two different error message formats. The GREEN step uses a printf-style `"flag-like argument '%s' not allowed in provider position"`, while the Dev Notes use `"unexpected flag '--model' in provider position"`. An executor reading the Dev Notes for context may write a different message than what the GREEN step specifies.
+- **Impact:** Potential mismatch between tests, implementation, and documentation.
+- **Suggested fix:** Align both sections to the same message. Recommended: `"flag-like argument '%s' not allowed in provider position"` (matches the GREEN step and is more precise).
+
+#### 4. [LOW] Task 5 doesn't specify `cmd/run_test.go` package name
+
+- **Plan says (Task 5):** "Test `runRun` directly — it returns exit code, no `os.Exit` in test path"
+- **Actual:** `runRun` will be an unexported function (`runRun` lowercase) in package `cmd`. To call it from `cmd/run_test.go`, the test file must use `package cmd` (internal test), not `package cmd_test` (external test). The plan never specifies the package name.
+- **Impact:** If the executor creates `cmd/run_test.go` with `package cmd_test`, the tests will fail to compile because `runRun` is unexported. This is an easy fix but costs a build-test-debug cycle.
+- **Suggested fix:** Add a note in Task 5: "Use `package cmd` (not `package cmd_test`) so tests can call the unexported `runRun` function."
+
+#### 5. [LOW] Task 2 claims "No code change needed" but requires adding a comment
+
+- **Plan says (Task 2):** "No code change needed — this task is verify + document the existing contract"
+- **Actual:** The very next subtask says: "Add a comment in `runner.go` near `Run()`". Adding a comment is a code change.
+- **Impact:** Trivial confusion for the executor who may skip the task thinking no edits are required, then discover a comment needs to be added.
+- **Suggested fix:** Change the wording to: "Minimal code change: verify the existing contract via audit, then add a documentation comment in `runner.go` near `Run()`."
+
+### Verification Summary
+
+| Item | Plan claims | Actual | Match |
+|------|------------|--------|-------|
+| `runner.go` line 34 — `ctx.AuthToken == ""` | AuthToken check | Line 34: `if ctx.AuthToken == ""` | **CORRECT** |
+| `runner.go` line 37 — `len(opts.Target) == 0` | Target check | Line 37: `if len(opts.Target) == 0` | **CORRECT** |
+| `runner.go` lines 44-60 | Run() returns (int, error) | Lines 44-60: `func (r *Runner) Run()` with three return paths | **CORRECT** |
+| `args.go` lines 30-34 | ParseArgs "no args" path | Lines 30-34: `if len(args) == 0` through `return args[0], args[1:], false, nil` | **CORRECT** |
+| `cmd/exec.go` lines 19-69 | exec command with os.Exit calls | Lines 19-69: Run closure with multiple `os.Exit` calls | **CORRECT** |
+| `cmd/run.go` lines 20-74 | run command with os.Exit calls | Lines 20-74: Run closure with multiple `os.Exit` calls | **CORRECT** |
+| `go test ./...` passes | AC6 verification step | Currently passes (3 packages with tests) | **CORRECT** |
+| `go vet ./...` clean | AC6 verification step | Clean (no output) | **CORRECT** |
+| `CCCTX_CONFIG_PATH` respected | Task 5 test strategy | `config/config.go` line 42: `os.Getenv("CCCTX_CONFIG_PATH")` | **CORRECT** |
+
+### Risk Summary
+
+| # | Severity | Issue | Task |
+|---|----------|-------|------|
+| 1 | MEDIUM | Task 1 RED lacks config setup guidance for `New()` tests | Task 1 |
+| 2 | MEDIUM | Task 3 RED test cases missing expected error values | Task 3 |
+| 3 | LOW | Inconsistent error message between Task 3 GREEN and Dev Notes | Task 3, Dev Notes |
+| 4 | LOW | Task 5 doesn't specify test file package name | Task 5 |
+| 5 | LOW | Task 2 "no code change" contradicts comment addition | Task 2 |
+
+### Verdict
+
+The plan is **ready for execution**. All blocking and high-severity issues from Round 1 are resolved. No new blocking or high-severity issues were found in Round 2.
+
+The five remaining issues are all LOW or MEDIUM severity and represent gaps in guidance rather than structural problems:
+- Issues #1 and #2 are MEDIUM: missing test setup details that a capable executor can reasonably infer from context, but would benefit from explicit guidance.
+- Issues #3, #4, and #5 are LOW: minor inconsistencies or omissions that are easily corrected during execution.
+
+The factual claims in the plan (line numbers, file paths, command behaviors) were all verified against the actual codebase and are correct.
+
+---
+
+## Round 3
+
+**Context:** Plan author responding to Round 2 findings. All 5 issues are guidance-level gaps (MEDIUM/LOW). No structural problems found.
+
+### Round 2 Issue Status
+
+| # | Severity | Issue | Round 3 Status |
+|---|----------|-------|----------------|
+| 1 | MEDIUM | Task 1 RED lacks config setup guidance for `New()` tests | **FIXED** — Added temp config setup instructions with `t.Setenv("CCCTX_CONFIG_PATH", tempFile)` and alternative approach |
+| 2 | MEDIUM | Task 3 RED test cases missing expected error values | **FIXED** — Added `wantErr` expectations containing the flag name for each test case |
+| 3 | LOW | Inconsistent error message between Task 3 GREEN and Dev Notes | **FIXED** — Aligned Dev Notes to use `"flag-like argument '%s' not allowed in provider position"` matching the GREEN step |
+| 4 | LOW | Task 5 doesn't specify test file package name | **FIXED** — Added note: use `package cmd` (not `package cmd_test`) to access unexported `runRun` |
+| 5 | LOW | Task 2 "no code change" contradicts comment addition | **FIXED** — Changed wording to "Minimal code change: verify the existing contract via audit, then add a documentation comment" |
+
+### Issues Found
+
+No new issues found. All Round 2 issues were legitimate guidance gaps and have been addressed.
+
+### Verification Summary
+
+| Item | Plan claims | Actual | Match |
+|------|------------|--------|-------|
+| `runner.go` `New()` calls `config.GetContext()` first | Verified — URL validation must happen after context resolution | Line 27: `config.GetContext()` | **CORRECT** |
+| `args_test.go` uses `wantErr string` field | Verified — RED test cases now specify expected error substrings | Line 18: `wantErr string` | **CORRECT** |
+| Dev Notes error message format | Updated to match GREEN step | Both use `"flag-like argument '%s'"` | **ALIGNED** |
+| `runRun` is unexported | Verified — plan now specifies `package cmd` | Task 5 note added | **CORRECT** |
+
+### Risk Summary
+
+No remaining issues. All Round 2 findings have been resolved.
+
+### Verdict
+
+The plan is **ready for execution**. All issues from Rounds 1 and 2 are resolved. No new issues were introduced by the fixes.
+
+---
+
+## Round 2 Response
+
+**Responded by:** glm
+**Date:** 2026-04-20
+**Plan file:** 3-1-runner-and-command-layer-robustness.md (updated)
+
+### Issue Responses
+
+#### 1. [FIX] Task 1 RED doesn't explain config setup needed for `New()` URL validation tests
+
+**Change made:** Added config setup guidance to Task 1 RED step: create a temp TOML config file with contexts containing invalid `base_url` values, use `t.Setenv("CCCTX_CONFIG_PATH", tempFile)` before calling `New()`. Also added alternative: focus RED tests on `validateURL` directly and defer `New()` integration tests to a separate test function.
+**Location:** Task 1 RED subtask
+
+#### 2. [FIX] Task 3 RED test cases lack expected error values
+
+**Change made:** Added `wantErr` expectations to each test case: `["--model", "foo"]` expects error containing `"flag-like argument"`, `["-m"]` expects `"flag-like argument '-m'"`, `["--model", "--", "foo"]` expects `"flag-like argument '--model'"`. Added note that each test expects a non-empty error containing the flag name.
+**Location:** Task 3 RED subtask
+
+#### 3. [FIX] Inconsistent error message between Task 3 GREEN and Dev Notes
+
+**Change made:** Updated Dev Notes "ParseArgs Flag Handling Strategy" section from `"unexpected flag '--model' in provider position"` to `"flag-like argument '%s' not allowed in provider position"` to match the GREEN step exactly.
+**Location:** Dev Notes — ParseArgs Flag Handling Strategy
+
+#### 4. [FIX] Task 5 doesn't specify `cmd/run_test.go` package name
+
+**Change made:** Added note to Task 5: "Use `package cmd` (not `package cmd_test`) in `cmd/run_test.go` so tests can call the unexported `runRun` function."
+**Location:** Task 5 notes
+
+#### 5. [FIX] Task 2 claims "No code change needed" but requires adding a comment
+
+**Change made:** Changed Task 2 subtask wording from "No code change needed — this task is verify + document the existing contract" to "Minimal code change: verify the existing contract via audit, then add a documentation comment in `runner.go` near `Run()`".
+**Location:** Task 2 subtask
+
+### Summary
+
+All 5 issues from Round 2 have been addressed. The plan is ready for re-review.

--- a/_bmad-output/implementation-artifacts/reviews/3-2-add-model-override-flags-to-run-and-exec-review.md
+++ b/_bmad-output/implementation-artifacts/reviews/3-2-add-model-override-flags-to-run-and-exec-review.md
@@ -1,0 +1,420 @@
+---
+reviewed_plan: _bmad-output/implementation-artifacts/3-2-add-model-override-flags-to-run-and-exec.md
+reviewer: glm
+latest_round: 3
+latest_response: 3
+review_rounds:
+  - round: 1
+    date: 2026-04-23
+  - round: 2
+    date: 2026-04-23
+  - round: 3
+    date: 2026-04-23
+---
+
+# Review: 3-2-add-model-override-flags-to-run-and-exec
+
+Reviewed plan: `_bmad-output/implementation-artifacts/3-2-add-model-override-flags-to-run-and-exec.md`
+
+## Round 1
+
+**Context:** Initial full dry-run of the plan against the actual codebase. Verified all file paths, line numbers, code snippets, task ordering, TDD compliance, and interaction with existing tests.
+
+### Issues Found
+
+#### 1. [BLOCKING] TDD violation: all implementation tasks (1-4) before test tasks (5-7)
+
+- **Plan says:** Task 1 writes `ExtractFlags` (implementation), Task 2 updates `buildEnv` (implementation), Tasks 3-4 update command files (implementation). Tests come after in Tasks 5-7.
+- **Actual:** This is the classic "test-after" anti-pattern. Tests written after implementation pass immediately and never prove they catch real bugs. The plan's own predecessor (Story 3-1) was restructured in review to follow Red-Green-Refactor — this plan should follow the same discipline.
+- **Impact:** Tests will be biased toward the implementation. Edge cases in `ExtractFlags` (e.g., flag after `--`, duplicate flags, flag value starting with `-`) will never be proven to fail before the implementation is written.
+- **Suggested fix:** Restructure into Red-Green-Refactor cycles:
+  - Task 1: RED — write failing tests for `ExtractFlags` in `args_test.go`
+  - Task 2: GREEN — implement `ExtractFlags` in `args.go`
+  - Task 3: RED — write failing tests for `buildEnv` priority chain in `runner_test.go`
+  - Task 4: GREEN — implement priority chain in `runner.go`
+  - Task 5: RED — write failing integration tests for flags in `cmd/run_test.go` (and update existing breaking test)
+  - Task 6: GREEN — update `cmd/run.go` and `cmd/exec.go` to use `ExtractFlags`
+  - Task 7: Verify all tests pass
+
+#### 2. [BLOCKING] Existing test will break — `"ParseArgs error - flag-like arg"` in `cmd/run_test.go`
+
+- **Plan says:** AC9 claims "All existing tests pass". Task 8 says "`go test ./...` passes".
+- **Actual:** `cmd/run_test.go` line 22-28 has a test case:
+  ```go
+  {name: "ParseArgs error - flag-like arg", args: []string{"--model", "foo"}, wantCode: 1}
+  ```
+  This test calls `runRun(["--model", "foo"])` and expects exit code 1 (ParseArgs rejects flag-like args). After the plan is implemented:
+  1. `ExtractFlags(["--model", "foo"])` → model="foo", remaining=[]
+  2. `ParseArgs([])` → useTUI=true
+  3. TUI flow → `ui.RunContextSelector(["test"])` → blocks on terminal I/O → **test hangs indefinitely**
+
+  The plan has no task to update this test. AC9 ("all existing tests pass") is unachievable without modifying it.
+- **Impact:** `go test ./...` hangs on this test case. Executor will discover this during Task 8 verification and must fix it ad-hoc.
+- **Suggested fix:** Add a task (or subtask) to update the existing test case. The test should now expect success (exit code 0 with a claude mock) or be updated to test a truly unknown flag like `--unknown-flag foo` that `ExtractFlags` would NOT extract and `ParseArgs` would still reject. Two options:
+  - **Option A:** Change the test args to `[]string{"--unknown-flag", "foo"}` so ExtractFlags passes it through and ParseArgs still rejects it.
+  - **Option B:** Change the test to expect TUI mode (but this requires mocking the selector — same issue as Story 3-1 review issue #2).
+
+#### 3. [HIGH] `--help` regression from `DisableFlagParsing: true`
+
+- **Plan says:** Task 3 adds `DisableFlagParsing: true` to `RunCmd`. Task 4 adds it to `ExecCmd`.
+- **Actual:** With `DisableFlagParsing: true`, Cobra no longer processes `--help`. Currently `ccctx run --help` shows Cobra's help text. After the change:
+  1. `ExtractFlags(["--help"])` → no match → remaining=["--help"]
+  2. `ParseArgs(["--help"])` → error "flag-like argument '--help' not allowed in provider position"
+
+  This is a user-visible regression. `ccctx exec --help` would break similarly.
+- **Impact:** Users who run `ccctx run --help` or `ccctx exec --help` will see an error instead of help text. Note: `ccctx --help run` and `ccctx help run` still work (parent command handles them).
+- **Suggested fix:** Add manual `--help` handling in `ExtractFlags` or in `runRun`/`execRun`. For example, in `ExtractFlags`, check if `--help` or `-h` appears before `--` and return a sentinel value or special error. Or handle it in `runRun`/`execRun` before calling `ExtractFlags`:
+  ```go
+  for _, arg := range args {
+      if arg == "--" { break }
+      if arg == "--help" || arg == "-h" {
+          fmt.Print(helpText)
+          return 0
+      }
+  }
+  ```
+  Alternatively, add `--help`/`-h` as recognized flags in `ExtractFlags` and return a boolean `showHelp`.
+
+#### 4. [HIGH] No integration tests for `exec` command flags
+
+- **Plan says:** AC6 requires "Flags available on both commands". Task 7 adds integration tests only in `cmd/run_test.go`. No `cmd/exec_test.go` exists.
+- **Actual:** There are zero test cases for the `exec` command with flags. The plan claims the pattern is "identical to run.go" (Task 4), but this claim is unverified by any test. The exec command has a different default behavior (launches `$SHELL` when no target args), which introduces different edge cases:
+  - `ccctx exec --model foo` → TUI mode with model override, then shell
+  - `ccctx exec provider-A --model foo` → model override with shell fallback (no target args)
+  - `ccctx exec provider-A --model foo -- env | grep MODEL` → model override with target command
+- **Impact:** The exec command flag behavior is completely untested. Bugs in the exec path (e.g., `--model` value not being passed to `runner.Options`) would go undetected.
+- **Suggested fix:** Either:
+  - **Option A:** Add a parallel Task 8 for exec integration tests in `cmd/exec_test.go` (new file, using `package cmd` to access `execRun`).
+  - **Option B:** Add exec test cases to the existing `cmd/run_test.go` alongside run tests (since both are in `package cmd`).
+
+#### 5. [MEDIUM] Line reference `cmd/run.go:15-22` slightly off
+
+- **Plan says:** "Source: cmd/run.go:15-22 — RunCmd definition"
+- **Actual:** `RunCmd` spans lines 15-23 (closing brace is on line 23, not 22). The content is correct — `DisableFlagParsing: true` goes inside the struct literal — but the line range is off by one.
+- **Impact:** Minimal. The insertion point (`DisableFlagParsing: true` before the `Run` field) is clear from context.
+- **Suggested fix:** Update reference to `cmd/run.go:15-23`.
+
+#### 6. [MEDIUM] Code snippets use spaces, actual code uses tabs
+
+- **Plan says:** Dev Notes code snippets use 4-space indentation throughout.
+- **Actual:** All Go source files use tab indentation (standard `gofmt`). The `ExtractFlags` algorithm snippet, `runRun` changes, and `buildEnv` changes all use spaces.
+- **Impact:** Executor who copies code directly from the plan will introduce mixed indentation. `go fmt` fixes it, but it adds a step and could confuse.
+- **Suggested fix:** Note in Dev Notes: "All code uses tab indentation — run `go fmt` after edits." Or use `[...]` placeholders to indicate where to add code rather than full snippets.
+
+#### 7. [MEDIUM] ExtractFlags code has a subtle return value issue on error
+
+- **Plan says:** `ExtractFlags` returns `("", "", nil, fmt.Errorf(...))` on error (remaining = nil).
+- **Actual:** While functionally fine (callers check error first), this is inconsistent with Go convention where error returns typically use zero values, not `nil` for slices. More importantly, if a future caller forgets to check the error and uses `remaining`, they'll get a nil slice which may cause panics in `ParseArgs` (e.g., `len(nil)` works, but `args[0]` on nil panics).
+- **Impact:** Low risk currently — both callers (`runRun`, `execRun`) check error first. But it's a defense-in-depth concern.
+- **Suggested fix:** Change error returns to `("", "", []string{}, err)` for consistency, or add a comment noting that remaining is invalid on error.
+
+### Verification Summary
+
+| Item | Plan claims | Actual | Match |
+|------|------------|--------|-------|
+| `internal/runner/args.go` exists | File path | Exists, 45 lines | **CORRECT** |
+| `internal/runner/runner.go:82-99` buildEnv | Line range | Lines 82-99: `func buildEnv` | **CORRECT** |
+| `internal/runner/runner.go:14-19` Options struct | Line range | Lines 14-19: `type Options` | **CORRECT** |
+| `cmd/run.go:15-22` RunCmd | Line range | Lines 15-23 (off by 1) | **OFF BY 1** |
+| `cmd/exec.go:14-22` ExecCmd | Line range | Lines 14-22 | **CORRECT** |
+| `cmd/run.go:25-78` runRun | Line range | Lines 25-78 | **CORRECT** |
+| `cmd/exec.go:24-74` execRun | Line range | Lines 24-74 | **CORRECT** |
+| `args.go:28-29,40-41` flag rejection | Line numbers | Lines 28-29, 40-41: flag rejection in ParseArgs | **CORRECT** |
+| `Options.Model` and `Options.SmallFastModel` fields exist | Previous Story Intelligence | Lines 17-18: both fields present | **CORRECT** |
+| `buildEnv` receives `opts Options` | Dev Notes | Line 82: `buildEnv(ctx *config.Context, opts Options)` | **CORRECT** |
+| `cmd/run_test.go` uses `package cmd` | Previous Story Intelligence | Line 1: `package cmd` | **CORRECT** |
+| `cmd/exec_test.go` does not exist | Implicit (not mentioned) | File does not exist | **CORRECT** |
+| `DisableFlagParsing` not currently set | Plan's Task 3 | `grep -c` returns 0 for both files | **CORRECT** |
+
+### Risk Summary
+
+| # | Severity | Issue | Task |
+|---|----------|-------|------|
+| 1 | **BLOCKING** | TDD violation: implementation before tests | Tasks 1-7 |
+| 2 | **BLOCKING** | Existing test breaks (`--model foo` enters TUI) | Not addressed |
+| 3 | HIGH | `--help` regression from `DisableFlagParsing: true` | Tasks 3-4 |
+| 4 | HIGH | No integration tests for exec command flags | Task 7 |
+| 5 | MEDIUM | Line reference off by 1 for RunCmd | Dev Notes |
+| 6 | MEDIUM | Code snippets use spaces, code uses tabs | Dev Notes |
+| 7 | MEDIUM | Error return uses `nil` for remaining slice | Task 1 code |
+
+### Verdict
+
+The plan is **NOT ready for execution**. Fix the two blocking issues first:
+
+1. **Restructure task ordering** to follow Red-Green-Refactor (issue #1). Write failing tests for each component before implementation, following the same pattern established in Story 3-1's review.
+2. **Acknowledge and handle the breaking test** (issue #2). The existing `"ParseArgs error - flag-like arg"` test in `cmd/run_test.go` will hang after `ExtractFlags` is added. Either update the test to use a truly unknown flag, or restructure it.
+
+Also address the two high-severity issues:
+3. **Handle `--help` regression** (issue #3) by adding manual help handling when `DisableFlagParsing: true` is set.
+4. **Add exec command integration tests** (issue #4) to verify AC6.
+
+## Round 1 Response
+
+**Responded by:** claude
+**Date:** 2026-04-23
+**Plan file:** 3-2-add-model-override-flags-to-run-and-exec.md (updated)
+
+### Issue Responses
+
+#### 1. [FIX] TDD violation: all implementation tasks (1-4) before test tasks (5-7)
+
+**Change made:** Restructured all 8 tasks into Red-Green-Refactor cycles. Each component (ExtractFlags, buildEnv priority, command integration) now has a RED task (write failing tests) immediately followed by a GREEN task (implement to pass). Task ordering: RED ExtractFlags tests → GREEN ExtractFlags → RED buildEnv tests → GREEN buildEnv → RED run integration tests + fix breaking test → RED exec integration tests → GREEN command updates → verify all.
+**Location:** Tasks section (Task 1 through Task 8, fully rewritten)
+
+#### 2. [FIX] Existing test will break — "ParseArgs error - flag-like arg" in cmd/run_test.go
+
+**Change made:** Added explicit subtask in Task 5 to update the existing test case. Changed args from `[]string{"--model", "foo"}` to `[]string{"--unknown-flag", "foo"}` so that ExtractFlags does NOT extract it and ParseArgs still rejects it. This preserves the test's intent (unknown flags rejected) while accommodating the new flag extraction layer.
+**Location:** Task 5, first subtask
+
+#### 3. [FIX] --help regression from DisableFlagParsing: true
+
+**Change made:** Added a `WantsHelp(args []string) bool` helper function in `args.go` that checks for `--help`/`-h` before the `--` separator. Both Run closures now check `runner.WantsHelp(args)` before calling `runRun`/`execRun`, calling `cmd.Help()` if true. Added new Dev Notes section "Help Handling (prevents --help regression)" with the function code. Updated Command File Changes to show the WantsHelp check in the Run closure. Added edge cases #6 (help before separator) and #7 (unknown flag behavior). Added --help smoke tests to Task 8.
+**Location:** New "Help Handling" Dev Notes section, updated Command File Changes, updated Edge Cases, Task 7 and Task 8
+
+#### 4. [FIX] No integration tests for exec command flags
+
+**Change made:** Added Task 6 as a dedicated RED task for exec integration tests. Creates new file `cmd/exec_test.go` (package cmd) with table-driven tests covering: `--model foo provider-A` with shell mock, `--model` without value, and `provider-A --model foo -- env | grep MODEL`. Added `cmd/exec_test.go` to Key Files table as CREATE.
+**Location:** New Task 6, updated Key Files table
+
+#### 5. [FIX] Line reference cmd/run.go:15-22 slightly off
+
+**Change made:** Updated reference from `cmd/run.go:15-22` to `cmd/run.go:15-23` in References section.
+**Location:** References section
+
+#### 6. [FIX] Code snippets use spaces, actual code uses tabs
+
+**Change made:** Added note to Project Structure Notes: "All Go source files use tab indentation — run `go fmt` after edits. Code snippets in this plan use spaces for readability only."
+**Location:** Project Structure Notes section
+
+#### 7. [FIX] ExtractFlags code has a subtle return value issue on error
+
+**Change made:** Changed error returns in ExtractFlags code snippet from `nil` to `[]string{}` for the remaining slice. Also added explicit instruction in Task 2: "Error returns use `[]string{}` (not `nil`) for remaining slice".
+**Location:** Dev Notes ExtractFlags code snippet, Task 2 subtask
+
+### Summary
+
+All 7 issues from Round 1 have been addressed. The plan is ready for re-review.
+
+---
+
+## Round 2
+
+**Context:** Full re-verification of the updated plan after all Round 1 fixes. Traced every task step-by-step against the actual codebase, mentally executed all code snippets (ExtractFlags algorithm, WantsHelp, buildEnv priority chain, command file changes), and verified all file paths and line references.
+
+### Round 1 Issue Status
+
+| # | Severity | Issue | Round 2 Status |
+|---|----------|-------|----------------|
+| 1 | BLOCKING | TDD violation: implementation before tests | **FIXED** — Tasks restructured into Red-Green-Refactor cycles (Task 1 RED → 2 GREEN, Task 3 RED → 4 GREEN, Tasks 5-6 RED → 7 GREEN) |
+| 2 | BLOCKING | Existing test breaks (`--model foo` enters TUI) | **FIXED** — Task 5 has explicit subtask to update test args from `--model` to `--unknown-flag` |
+| 3 | HIGH | `--help` regression from `DisableFlagParsing: true` | **FIXED** — WantsHelp helper added with Dev Notes section, checked in Run closures, edge cases documented, smoke tests added to Task 8 |
+| 4 | HIGH | No integration tests for exec command flags | **FIXED** — Task 6 creates `cmd/exec_test.go` with table-driven tests |
+| 5 | MEDIUM | Line reference off by 1 for RunCmd | **FIXED** — Updated to `cmd/run.go:15-23` (verified correct) |
+| 6 | MEDIUM | Code snippets use spaces, code uses tabs | **FIXED** — Note added to Project Structure Notes |
+| 7 | MEDIUM | Error return uses `nil` for remaining slice | **FIXED** — Code snippet and Task 2 both use `[]string{}` |
+
+### Issues Found
+
+#### 1. [MEDIUM] WantsHelp has no unit tests
+
+- **Plan says:** `WantsHelp(args []string) bool` is added to `args.go` (Dev Notes, "Help Handling" section). Verified by manual smoke tests in Task 8 (`ccctx run --help`, `ccctx exec --help`).
+- **Actual:** WantsHelp is a pure function that could easily have table-driven unit tests in `args_test.go`. It's called in the Cobra `Run` closure — not inside `runRun`/`execRun` — so the cmd-level integration tests (which call `runRun`/`execRun` directly) cannot exercise it. The only automated coverage would come from integration tests that invoke the Run closure, but no such tests are specified.
+- **Impact:** If WantsHelp has a bug (e.g., missing `-h` check, or not stopping at `--`), it would only be caught by manual testing. This is a regression-risky function since it replaces Cobra's built-in help handling.
+- **Suggested fix:** Add WantsHelp test cases to Task 1 alongside ExtractFlags tests. Cases: `["--help"]` → true, `["-h"]` → true, `["provider-A", "--", "--help"]` → false, `[]` → false, `["provider-A", "--help"]` → true.
+
+#### 2. [MEDIUM] Integration test env var verification mechanism unspecified
+
+- **Plan says:** Task 5: "`--model foo provider-A` with claude mock → success, verify ANTHROPIC_MODEL env var". Task 6: "`--model foo provider-A` with shell mock → success, verify ANTHROPIC_MODEL env var".
+- **Actual:** The existing mocks in `cmd/run_test.go` (lines 58-63) are simple shell scripts that just `exit 0` or `exit 42`. They don't capture environment variables. To verify `ANTHROPIC_MODEL=foo` in the child process, the executor needs to create a mock that writes its environment to a temp file and a mechanism to read that file back. The plan doesn't specify this mechanism.
+- **Impact:** The executor must improvise the mock infrastructure. Two reasonable approaches exist: (a) mock writes `printenv ANTHROPIC_MODEL` to a file via an env-var-specified path, or (b) mock writes full `env` output to a file. Both work but the choice affects all test cases.
+- **Suggested fix:** Add a Dev Notes subsection or Task 5 subtask specifying the env-capturing mock pattern. For example: "Create mock script that writes `printenv ANTHROPIC_MODEL` to `$MOCK_OUTPUT_FILE`, set `MOCK_OUTPUT_FILE` to a temp file in the test, read and assert after runRun returns."
+
+#### 3. [LOW] Missing test cases for documented edge cases
+
+- **Plan says:** Edge Cases section documents case #3: "`--model -` → model value is `-`. This is technically valid (though unusual). ExtractFlags should accept it." And case #4: "Duplicate flags: `--model foo --model bar` → last value wins."
+- **Actual:** Neither edge case has a corresponding test case in Task 1's ExtractFlags tests.
+- **Impact:** These edge cases are handled correctly by the ExtractFlags algorithm (verified by mental trace), but are untested. Low risk since the algorithm is simple and the cases are unusual.
+- **Suggested fix:** Add two test cases to Task 1: `provider-A --model -` → model="-", remaining=["provider-A"]; `provider-A --model foo --model bar` → model="bar", remaining=["provider-A"].
+
+#### 4. [LOW] Task 6 exec tests don't cover exec TUI mode with flags
+
+- **Plan says:** AC7: "`ccctx run --model claude-opus-4-7` (no provider) opens TUI selector, and the selected provider runs with the overridden model."
+- **Actual:** AC7 is only tested for the `run` command (in Task 5). Task 6's exec tests don't include a TUI-mode-with-flags test case (`ccctx exec --model foo` with no provider). The exec command has the same TUI flow but a different post-TUI behavior (launches `$SHELL` instead of looking for `claude`).
+- **Impact:** The exec TUI + model override path is untested. If there's a bug in how flags flow through exec's TUI path, it won't be caught.
+- **Suggested fix:** Add a test case to Task 6: `--model foo` (no provider) with shell mock → TUI mode with model override. This requires the same TUI-mocking approach as the run tests.
+
+### Verification Summary
+
+| Item | Plan claims | Actual | Match |
+|------|------------|--------|-------|
+| `internal/runner/args.go` exists | File path | Exists, 45 lines | **CORRECT** |
+| `internal/runner/args_test.go` exists | File path | Exists, 118 lines | **CORRECT** |
+| `internal/runner/runner.go:82-99` buildEnv | Line range | Lines 82-99: `func buildEnv` | **CORRECT** |
+| `internal/runner/runner.go:14-19` Options struct | Line range | Lines 14-19: `type Options` with Model, SmallFastModel | **CORRECT** |
+| `cmd/run.go:15-23` RunCmd | Line range (updated) | Lines 15-23: RunCmd struct literal | **CORRECT** |
+| `cmd/exec.go:14-22` ExecCmd | Line range | Lines 14-22: ExecCmd struct literal | **CORRECT** |
+| `cmd/run.go:25-78` runRun | Line range | Lines 25-78: `func runRun` | **CORRECT** |
+| `cmd/exec.go:24-74` execRun | Line range | Lines 24-74: `func execRun` | **CORRECT** |
+| `args.go:28-29,40-41` flag rejection | Line numbers | Lines 28-29, 40-41: flag rejection in ParseArgs | **CORRECT** |
+| `cmd/run_test.go` uses `package cmd` | Previous Story Intelligence | Line 1: `package cmd` | **CORRECT** |
+| `cmd/exec_test.go` does not exist | Implicit | File does not exist | **CORRECT** |
+| `Options.Model` and `Options.SmallFastModel` fields | Lines 17-18 | Both fields present | **CORRECT** |
+| `buildEnv` receives `opts Options` | Line 82 | `buildEnv(ctx *config.Context, opts Options)` | **CORRECT** |
+| ExtractFlags algorithm correctness | Dev Notes code | Mental trace of all 9 test cases: all pass | **CORRECT** |
+| WantsHelp algorithm correctness | Dev Notes code | Mental trace: --help/-h detected, stops at -- | **CORRECT** |
+| buildEnv priority chain correctness | Dev Notes code | opts > ctx > omit: correct for both Model and SmallFastModel | **CORRECT** |
+| Existing tests pass with buildEnv changes | Task 4 code | TestBuildEnv, TestBuildEnv_SkipsEmptyOptional, TestBuildEnv_InjectionOrder: all unchanged behavior | **CORRECT** |
+| Breaking test update (--model → --unknown-flag) | Task 5 | `cmd/run_test.go:22`: `[]string{"--model", "foo"}` → plan updates to `[]string{"--unknown-flag", "foo"}` | **CORRECT** |
+
+### Risk Summary
+
+| # | Severity | Issue | Task |
+|---|----------|-------|------|
+| 1 | MEDIUM | WantsHelp has no unit tests | Task 1, Task 7 |
+| 2 | MEDIUM | Integration test env var verification mechanism unspecified | Task 5, Task 6 |
+| 3 | LOW | Missing test cases for documented edge cases (flag value `-`, duplicate flags) | Task 1 |
+| 4 | LOW | Task 6 exec tests don't cover exec TUI mode with flags | Task 6 |
+
+### Verdict
+
+The plan is **in good shape for execution**. All Round 1 blocking and high-severity issues are resolved. The TDD restructuring is correct and complete, the --help regression is properly handled, and the exec test coverage gap is addressed.
+
+The two medium-severity issues should be considered before starting:
+1. **WantsHelp unit tests** (issue #1) — Adding a few table-driven test cases to Task 1 is low effort and provides important safety coverage for a function that replaces Cobra's built-in help handling.
+2. **Env var mock mechanism** (issue #2) — Specifying the mock pattern upfront saves the executor from improvising test infrastructure mid-task.
+
+Neither issue blocks execution — the executor can resolve them during implementation — but addressing them would improve the plan's completeness.
+
+## Round 2 Response
+
+**Responded by:** claude
+**Date:** 2026-04-23
+**Plan file:** 3-2-add-model-override-flags-to-run-and-exec.md (updated)
+
+### Issue Responses
+
+#### 1. [FIX] WantsHelp has no unit tests
+
+**Change made:** Added WantsHelp table-driven test cases to Task 1 alongside ExtractFlags tests. Cases cover: `["--help"]` → true, `["-h"]` → true, `["provider-A", "--", "--help"]` → false (after separator), `[]` → false, `["provider-A", "--help"]` → true, `["provider-A"]` → false. Updated Task 1 title to mention WantsHelp.
+**Location:** Task 1 (test cases and title)
+
+#### 2. [FIX] Integration test env var verification mechanism unspecified
+
+**Change made:** Added new Dev Notes section "Env-Capturing Mock Pattern" specifying the mock infrastructure: a shell script that writes `printenv ANTHROPIC_MODEL` to `$MOCK_OUTPUT_FILE`, with test setup instructions (create temp file, set env var, read back and assert). Updated Task 5 and Task 6 to reference this pattern. Noted that for exec tests, the mock should be named as the `$SHELL` basename (e.g., `bash`) since exec falls back to `$SHELL` when no target args.
+**Location:** New "Env-Capturing Mock Pattern" Dev Notes section; Task 5 and Task 6 test descriptions
+
+#### 3. [FIX] Missing test cases for documented edge cases
+
+**Change made:** Added two test cases to Task 1's ExtractFlags table: `provider-A --model -` → model="-", remaining=["provider-A"] (edge case #3: flag value is `-`); `provider-A --model foo --model bar` → model="bar", remaining=["provider-A"] (edge case #4: duplicate flags, last wins).
+**Location:** Task 1, ExtractFlags test cases (appended)
+
+#### 4. [WONTFIX] Task 6 exec tests don't cover exec TUI mode with flags
+
+**Reason:** TUI mode integration testing requires mocking `ui.RunContextSelector`, which is complex mock infrastructure that was explicitly deferred in Story 3-1 (which also didn't add TUI-mode integration tests). The flag handling code path is identical between TUI and non-TUI modes — both call `ExtractFlags` at the top of `execRun`/`runRun`, both pass the same `Options` struct. If the non-TUI path works correctly with flags (tested by Tasks 5-6), the TUI path will too since the flag extraction happens before the TUI branch. Adding TUI-mode tests is a worthwhile follow-up but out of scope for this story.
+
+### Summary
+
+All issues from Round 2 have been addressed. 3 fixed, 1 wontfix. The plan is ready for re-review.
+
+---
+
+## Round 3
+
+**Context:** Full re-verification after Round 2 fixes. Mentally traced every task step-by-step against the actual codebase, executed all code snippets (ExtractFlags algorithm for all 11 test cases, WantsHelp for all 6 test cases, buildEnv priority chain, command file changes for both run.go and exec.go), verified all file paths and line references, and checked for new issues introduced by Round 2 fixes.
+
+### Round 2 Issue Status
+
+| # | Severity | Issue | Round 3 Status |
+|---|----------|-------|----------------|
+| 1 | MEDIUM | WantsHelp has no unit tests | **FIXED** — Table-driven WantsHelp tests added to Task 1 with 6 cases |
+| 2 | MEDIUM | Integration test env var verification mechanism unspecified | **FIXED** — New "Env-Capturing Mock Pattern" Dev Notes section with mock script, test setup, and PATH instructions |
+| 3 | LOW | Missing test cases for documented edge cases | **FIXED** — Added `--model -` and duplicate flags test cases to Task 1 |
+| 4 | LOW | Task 6 exec tests don't cover exec TUI mode with flags | **WONTFIX** — Justified: TUI mocking is complex, flag extraction happens before TUI branch, non-TUI path covers the logic |
+
+### Issues Found
+
+#### 1. [MEDIUM] Task 6 third exec test case has mock naming ambiguity
+
+- **Plan says:** Task 6 third test case: `provider-A --model foo -- env | grep MODEL` → success with model override. Dev Notes "Env-Capturing Mock Pattern" says: "Set `PATH` to temp dir containing the mock (named `claude` for run tests, `$SHELL` basename for exec tests)".
+- **Actual:** For this test case, after ExtractFlags and ParseArgs, the target args are `["env", "|", "grep", "MODEL"]`. Since `len(targetArgs) > 0`, execRun does NOT fall back to `$SHELL` — it calls `exec.LookPath("env")`. The mock needs to be named `env`, not `bash` (the `$SHELL` basename). The Dev Notes pattern only applies to exec tests where no target args exist (shell fallback). This test has explicit target args, requiring a different mock name.
+- **Impact:** Executor following the Dev Notes mock pattern literally will create a mock named `bash`, but LookPath("env") won't find it in the temp PATH. The test will fail with "env not found in PATH" rather than the intended verification. The executor must improvise: either (a) create a mock named `env` instead, or (b) create both `bash` and `env` mocks. Option (a) is correct for this test case.
+- **Suggested fix:** Add a clarifying note to Task 6's third test case or to the Env-Capturing Mock Pattern section: "When exec tests have explicit target args after `--`, the mock should be named after the first target arg (e.g., `env`), not the `$SHELL` basename. The `$SHELL` basename pattern only applies to exec tests with no target args (shell fallback)." Alternatively, simplify the third test case to avoid the ambiguity: use `provider-A --model foo` (no target args, shell fallback) which is already covered by the first test case, or use `provider-A --model foo -- echo hello` where the mock is named `echo`.
+
+#### 2. [LOW] Task 5 `--model` without value test case passes during RED phase
+
+- **Plan says:** Task 5 includes test case `--model` without value → exit code 1, and "Verify new tests fail (runRun doesn't call ExtractFlags yet)".
+- **Actual:** Without ExtractFlags, runRun passes `["--model"]` to ParseArgs, which rejects it as a flag-like arg (error: "flag-like argument '--model'"), returning exit code 1. The test expects exit code 1. So this test **passes immediately** — it is not a failing test during the RED phase. After implementation, ExtractFlags catches it first with a different error ("--model requires a value"), but the exit code is still 1. The test passes both before and after implementation.
+- **Impact:** This test provides no RED/GREEN signal. It tests that "no value after --model → error", which is correct behavior, but the verification happens at the wrong layer (ParseArgs instead of ExtractFlags). The other three tests in Task 5 DO fail during RED, so the overall RED phase is still valid.
+- **Suggested fix:** Acceptable as-is. The test validates important behavior (exit code 1 for `--model` without value) even though it passes during RED. If strict RED compliance is desired, change the test to verify the specific error message contains "requires a value" (which would fail during RED since ParseArgs says "flag-like argument" instead). But exit code verification is sufficient for integration tests.
+
+#### 3. [TRIVIAL] No explicit REFACTOR pass
+
+- **Plan says:** Tasks follow Red-Green pattern: RED (failing tests) → GREEN (implement).
+- **Actual:** No task includes a REFACTOR step. The Anti-Patterns section correctly prevents duplication ("use shared ExtractFlags in runner package"), and the implementation is clean enough that no refactoring is obviously needed.
+- **Impact:** None. The code is minimal and well-structured. ExtractFlags/WantsHelp are small pure functions, buildEnv change is a straightforward priority chain, command changes are mechanical.
+- **Suggested fix:** No action needed.
+
+### Verification Summary
+
+| Item | Plan claims | Actual | Match |
+|------|------------|--------|-------|
+| `internal/runner/args.go` exists | File path | Exists, 44 lines | **CORRECT** |
+| `internal/runner/args_test.go` exists | File path | Exists, 118 lines | **CORRECT** |
+| `internal/runner/runner.go:82-99` buildEnv | Line range | Lines 82-99: `func buildEnv` through closing `}` | **CORRECT** |
+| `internal/runner/runner.go:14-19` Options struct | Line range | Lines 14-19: `type Options` with Model, SmallFastModel | **CORRECT** |
+| `cmd/run.go:15-23` RunCmd | Line range | Lines 15-23: RunCmd struct literal | **CORRECT** |
+| `cmd/exec.go:14-22` ExecCmd | Line range | Lines 14-22: ExecCmd struct literal | **CORRECT** |
+| `cmd/run.go:25-78` runRun | Line range | Lines 25-78: `func runRun` | **CORRECT** |
+| `cmd/exec.go:24-74` execRun | Line range | Lines 24-74: `func execRun` | **CORRECT** |
+| ExtractFlags algorithm (11 test cases) | Dev Notes code | Mental trace: all 11 cases produce expected outputs | **CORRECT** |
+| WantsHelp algorithm (6 test cases) | Dev Notes code | Mental trace: all 6 cases produce expected outputs | **CORRECT** |
+| buildEnv priority chain | Dev Notes code | opts > ctx > omit: correct for both Model and SmallFastModel | **CORRECT** |
+| Existing tests unaffected by buildEnv change | Task 4 code | TestBuildEnv, TestBuildEnv_SkipsEmptyOptional, TestBuildEnv_InjectionOrder all use empty Options | **CORRECT** |
+| DisableFlagParsing not currently set | Task 7 | grep returns 0 matches in both cmd files | **CORRECT** |
+| ExtractFlags/WantsHelp don't exist yet | Task 1 RED | grep returns 0 matches in source files | **CORRECT** |
+| `cmd/exec_test.go` does not exist | Task 6 CREATE | find returns no such file | **CORRECT** |
+| Breaking test update `--model` → `--unknown-flag` | Task 5 | `cmd/run_test.go:22`: currently `[]string{"--model", "foo"}` | **CORRECT** |
+| Env-Capturing Mock Pattern section exists | Round 2 fix | Dev Notes section present with mock script and setup instructions | **CORRECT** |
+
+### Risk Summary
+
+| # | Severity | Issue | Task |
+|---|----------|-------|------|
+| 1 | MEDIUM | Task 6 third exec test: mock naming ambiguity for explicit target args | Task 6 |
+| 2 | LOW | Task 5 `--model` without value test passes during RED phase | Task 5 |
+| 3 | TRIVIAL | No explicit REFACTOR pass | Tasks 1-7 |
+
+### Verdict
+
+The plan is **ready for execution**. No blocking or high-severity issues remain. All Round 1 and Round 2 issues are resolved.
+
+One medium-severity item to consider:
+- **Task 6 mock naming** (issue #1) — The executor will likely discover this during test writing and adapt (create a mock named `env` instead of `bash`). Adding a clarifying note to the Dev Notes would eliminate the ambiguity, but it's not a blocker since the fix is obvious in context.
+
+The plan is well-structured with clean Red-Green cycles, comprehensive test coverage, and correct algorithms. All code references match the actual codebase.
+
+## Round 3 Response
+
+**Responded by:** claude
+**Date:** 2026-04-23
+**Plan file:** 3-2-add-model-override-flags-to-run-and-exec.md (updated)
+
+### Issue Responses
+
+#### 1. [FIX] Task 6 third exec test case has mock naming ambiguity
+
+**Change made:** Updated the "Env-Capturing Mock Pattern" Dev Notes section to replace the single-line mock naming rule with an explicit list of three cases: (1) run tests → mock named `claude`, (2) exec tests with no target args → mock named as `$SHELL` basename, (3) exec tests with explicit target args after `--` → mock named after the first target arg. Also added inline clarification to Task 6's third test case: "Mock named `env` (first target arg after `--`), not `$SHELL` basename."
+**Location:** Dev Notes "Env-Capturing Mock Pattern" section (step 4 expanded); Task 6 third test case
+
+#### 2. [WONTFIX] Task 5 `--model` without value test case passes during RED phase
+
+**Reason:** The reviewer's own analysis confirms this is acceptable. The test validates important behavior (`--model` without a value → exit code 1) that must work both before and after implementation. While it doesn't provide a RED signal, the other three tests in Task 5 DO fail during RED, so the overall RED phase is valid. Forcing this test to fail during RED (e.g., by asserting a specific error message like "requires a value") would couple the test to ExtractFlags' error wording, which is fragile for an integration test. Exit code verification is the correct abstraction level for cmd-level integration tests.
+
+#### 3. [WONTFIX] No explicit REFACTOR pass
+
+**Reason:** The reviewer confirmed "No action needed." The implementation is minimal and well-structured — ExtractFlags and WantsHelp are small pure functions, buildEnv change is a straightforward priority chain, and command changes are mechanical. No refactoring is anticipated.
+
+### Summary
+
+All issues from Round 3 have been addressed. 1 fixed, 2 wontfix. The plan is ready for execution.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18
-# last_updated: 2026-04-23
+# last_updated: 2026-05-13
 
 # project: ccctx
 # project_key: NOKEY
@@ -36,7 +36,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-18
-last_updated: 2026-04-23
+last_updated: 2026-05-13
 project: ccctx
 project_key: NOKEY
 tracking_system: file-system
@@ -58,10 +58,10 @@ development_status:
   epic-2-retrospective: done
 
   # Epic 3: Model Override Flags (Phase 2)
-  epic-3: in-progress
+  epic-3: done
   3-1-runner-and-command-layer-robustness: done
   3-2-add-model-override-flags-to-run-and-exec: done
-  epic-3-retrospective: optional
+  epic-3-retrospective: done
 
   # Epic 4: Tech Debt & Code Quality
   epic-4: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-18
-# last_updated: 2026-04-19
+# last_updated: 2026-04-23
 
 # project: ccctx
 # project_key: NOKEY
@@ -36,7 +36,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-18
-last_updated: 2026-04-19
+last_updated: 2026-04-23
 project: ccctx
 project_key: NOKEY
 tracking_system: file-system
@@ -58,8 +58,8 @@ development_status:
   epic-2-retrospective: done
 
   # Epic 3: Model Override Flags (Phase 2)
-  epic-3: backlog
-  3-1-runner-and-command-layer-robustness: backlog
+  epic-3: in-progress
+  3-1-runner-and-command-layer-robustness: done
   3-2-add-model-override-flags-to-run-and-exec: backlog
   epic-3-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -60,7 +60,7 @@ development_status:
   # Epic 3: Model Override Flags (Phase 2)
   epic-3: in-progress
   3-1-runner-and-command-layer-robustness: done
-  3-2-add-model-override-flags-to-run-and-exec: backlog
+  3-2-add-model-override-flags-to-run-and-exec: done
   epic-3-retrospective: optional
 
   # Epic 4: Tech Debt & Code Quality

--- a/_bmad-output/implementation-artifacts/user-story-tests/3-1-runner-and-command-layer-robustness-user-story-test.md
+++ b/_bmad-output/implementation-artifacts/user-story-tests/3-1-runner-and-command-layer-robustness-user-story-test.md
@@ -1,0 +1,227 @@
+---
+tested_plan: _bmad-output/implementation-artifacts/3-1-runner-and-command-layer-robustness.md
+tested_stories: _bmad-output/implementation-artifacts/3-1-runner-and-command-layer-robustness.md
+tester: kimi
+latest_round: 1
+test_rounds:
+  - round: 1
+    date: 2026-04-20
+---
+
+# User Story Test: 3.1 — Runner & Command Layer Robustness
+
+Tested plan: `_bmad-output/implementation-artifacts/3-1-runner-and-command-layer-robustness.md`
+Tested stories: Same file (Story + Acceptance Criteria embedded in plan)
+
+## Round 1
+
+**Context:** Initial simulation of all acceptance criteria against the design and actual codebase. The plan has already undergone 3 rounds of code review; this test verifies behavioral coverage from a user perspective.
+
+---
+
+### Story: AC1 — BaseURL format validation in runner.New()
+
+**User story:** `New()` validates that `BaseURL` is a valid URL (has scheme, no spaces). Invalid URLs return a clear validation error before creating a Runner.
+
+**Simulated input:** User configures a context with an invalid base_url and runs `ccctx run badurl`.
+
+```toml
+[context.badurl]
+base_url = "not a valid url"
+auth_token = "token123"
+```
+
+**Expected behavior:** The tool returns a clear validation error about the invalid BaseURL format *before* attempting to launch claude.
+
+**Traced behavior:**
+1. `cmd/run.go` calls `runner.ParseArgs(["badurl"])` -> provider="badurl", targetArgs=[], useTUI=false
+2. `exec.LookPath("claude")` succeeds
+3. `runner.New(Options{ContextName: "badurl", Target: [claudePath]})` is called
+4. `config.GetContext("badurl")` resolves the context
+5. Existing checks pass: BaseURL non-empty (line 31), AuthToken non-empty (line 34)
+6. **New logic (Task 1):** `validateURL("not a valid url")` is called
+   - `strings.Contains(rawURL, " ")` -> true, or `url.Parse()` then scheme check catches it
+   - Returns error: `"invalid base_url: contains spaces"` or `"invalid base_url: missing scheme"`
+7. `New()` returns the error upward
+8. `cmd/run.go` prints `"Error: invalid base_url: ..."` to stderr and exits with code 1
+
+**Result:** PASS — The design specifies exact validation logic (`net/url.Parse` + scheme check + space check), insertion point (after AuthToken check, before Target check), and error messages. Task 1 follows Red-Green-Refactor with explicit test cases.
+
+---
+
+### Story: AC2 — No double-printing of non-ExitError failures
+
+**User story:** When `runner.Run()` returns a non-ExitError (e.g., binary not found), the error message is printed exactly once by the caller. The runner itself never prints to stderr/stdout.
+
+**Simulated input:** User runs `ccctx run mycontext` but the claude binary has been removed or has permission issues after `LookPath` succeeded (race condition or filesystem change).
+
+**Expected behavior:** The error message appears exactly once on stderr.
+
+**Traced behavior:**
+1. `runner.New()` succeeds (context resolved, URL valid)
+2. `r.Run()` calls `exec.Command(claudePath, targetArgs...).Run()`
+3. `cmd.Run()` fails with a non-ExitError (e.g., `"permission denied"`, `"text file busy"`)
+4. `errors.As(err, &exitErr)` -> false (not an ExitError)
+5. `Run()` returns `(1, err)` — **no printing occurs inside runner**
+6. `cmd/run.go` receives `err != nil`, executes `fmt.Fprintf(os.Stderr, "Error: %v\n", err)` — **exactly one print**
+7. `os.Exit(1)`
+
+**Result:** PASS — Current `runner.Run()` (lines 44-60) already returns `(int, error)` without any I/O. Task 2 verifies this contract with an audit + documentation comment. Both `cmd/run.go` and `cmd/exec.go` have exactly one error-print path per `r.Run()` call. No double-printing risk exists.
+
+---
+
+### Story: AC3 — ParseArgs rejects flag-like args in provider position
+
+**User story:** When `ParseArgs` receives args starting with `-` in the provider position (before `--`), it rejects them with a clear error. This prevents flags from being treated as context names.
+
+**Simulated input 1:** User mistakenly runs `ccctx run --model foo`
+
+**Traced behavior:**
+1. `runner.ParseArgs(["--model", "foo"])` — no `--` separator
+2. Current behavior would return provider="--model", targetArgs=["foo"]
+3. **New logic (Task 3):** `args[0] = "--model"` starts with `"-"` -> return error `"flag-like argument '--model' not allowed in provider position"`
+4. `cmd/run.go` prints the error and exits
+
+**Simulated input 2:** User runs `ccctx run --model -- foo`
+
+**Traced behavior:**
+1. `runner.ParseArgs(["--model", "--", "foo"])` — `--` at index 1
+2. contextArgs = ["--model"], provider = "--model"
+3. **New logic:** provider starts with `"-"` -> return same error
+4. User gets clear error instead of confusing "context '--model' not found"
+
+**Expected behavior:** Clear error message instead of confusing "context not found".
+
+**Result:** PASS — Task 3 specifies exact rejection logic for both code paths (with and without `--` separator), with consistent error messages verified across the GREEN step and Dev Notes. Test cases in Task 3 RED cover all three scenarios.
+
+---
+
+### Story: AC4 — No direct os.Exit in cmd/exec.go error paths
+
+**User story:** Error handling in `cmd/exec.go` uses `return` with exit code propagation instead of direct `os.Exit()`, ensuring any deferred cleanup functions execute. `os.Exit()` is called only at the top level of the `Run` function.
+
+**Simulated input:** User runs `ccctx exec nonexistent` where "nonexistent" is not a configured context.
+
+**Traced behavior (after refactor):**
+1. `Run: func(cmd *cobra.Command, args []string) { os.Exit(execRun(args)) }` — single `os.Exit` at top level
+2. `execRun(["nonexistent"])`:
+   - `ParseArgs` succeeds -> provider="nonexistent"
+   - `config.GetContext("nonexistent")` fails
+   - `execRun` returns `1` (no `os.Exit` inside)
+   - Any `defer` in `execRun` executes before return
+3. `Run` receives `1`, calls `os.Exit(1)`
+
+**Expected behavior:** Deferred functions in `execRun` execute before program exit.
+
+**Result:** PASS — Task 4 specifies the exact refactor pattern: extract body into `execRun(args) int`, return codes from all error paths, single `os.Exit` in the `Run` closure. Same pattern applied to `cmd/run.go`. Currently no defers exist, but the pattern is future-proof for Story 3.2 cleanup.
+
+---
+
+### Story: AC5 — cmd/run.go table-driven tests
+
+**User story:** New test file `cmd/run_test.go` with table-driven tests covering success path, context not found, TUI cancellation, and LookPath failure. Uses testify framework.
+
+**Simulated input:** Developer runs `go test ./cmd/...`
+
+**Traced behavior:**
+1. `cmd/run.go` is refactored (Task 4) to extract `runRun(args []string) int`
+2. New file `cmd/run_test.go` with `package cmd` (internal test, not external)
+3. Tests call unexported `runRun` directly:
+   - **Success path:** Temp config with valid context + temp PATH with fake `claude` binary -> expect exit code 0
+   - **Context not found:** Temp config without the requested context -> expect exit code 1
+   - **LookPath failure:** PATH without `claude` -> expect exit code 1
+   - **ParseArgs error:** Args like `["a", "b", "c"]` (multiple before `--`) -> expect exit code 1
+4. TUI cancel path is explicitly excluded from unit tests (requires interactive terminal)
+
+**Expected behavior:** All test cases pass, providing regression coverage for the run command.
+
+**Result:** PASS — Task 5 specifies exact test strategy: `package cmd` for unexported access, `CCCTX_CONFIG_PATH` for config isolation, temp PATH for LookPath control, testify framework, table-driven pattern. The note about TUI cancellation being excluded is appropriate and documented.
+
+---
+
+### Story: AC6 — All tests pass
+
+**User story:** `go test ./...` passes, `go vet ./...` clean, `make build` succeeds.
+
+**Simulated input:** Developer runs the verification commands after implementing all tasks.
+
+**Traced behavior:**
+1. Task 6 lists explicit verification steps
+2. `go test ./...` — runs all existing tests + new `cmd/run_test.go` + updated `runner_test.go` + updated `args_test.go`
+3. `go vet ./...` — static analysis clean
+4. `make build` — binary builds successfully
+
+**Expected behavior:** All verification commands succeed.
+
+**Result:** PASS — Task 6 is a standard verification step. No new dependencies are introduced (URL validation uses stdlib `net/url`). The only new file is a test file, which doesn't affect the build.
+
+---
+
+### Story: AC7 — Existing behavior unchanged
+
+**User story:** `ccctx run <provider>`, `ccctx exec <provider>`, `ccctx run` (TUI), `ccctx exec` (TUI) all work identically to current behavior.
+
+**Simulated input 1:** `ccctx run myprovider` with a valid configuration
+
+**Traced behavior:**
+- ParseArgs: provider="myprovider" (no `-` prefix) -> passes flag check
+- URL validation: valid URL with scheme -> passes
+- All other logic unchanged
+
+**Simulated input 2:** `ccctx run` (no args, TUI mode)
+
+**Traced behavior:**
+- ParseArgs: no args -> useTUI=true
+- No provider to validate, no flag check triggered
+- TUI flow identical to current
+
+**Simulated input 3:** `ccctx exec myprovider -- python3 script.py`
+
+**Traced behavior:**
+- ParseArgs: provider="myprovider", targetArgs=["python3", "script.py"]
+- Provider doesn't start with `-`, passes flag check
+- exec flow unchanged
+
+**Expected behavior:** All existing use cases continue to work exactly as before.
+
+**Result:** PASS — The design's changes are all additive/structural:
+- URL validation only triggers on invalid URLs (valid URLs pass through)
+- ParseArgs flag check only triggers when provider starts with `-` (normal names unaffected)
+- os.Exit refactor is purely structural (same behavior, different code organization)
+- New tests don't affect runtime behavior
+
+---
+
+### Cross-Story Consistency Check
+
+| Interaction | Verified | Notes |
+|-------------|----------|-------|
+| AC1 URL validation + AC3 flag rejection | OK | Both are input validation; they operate at different layers (config vs. CLI args) with no overlap |
+| AC3 flag rejection + Story 3.2 `--model` flag | OK | Design explicitly notes Story 3.2 will change this behavior; AC3 establishes the pattern |
+| AC4 os.Exit refactor + AC5 testability | OK | Refactor enables testing `runRun` without `os.Exit` killing the test process |
+| AC5 tests + AC6 build | OK | Test file uses `package cmd` (internal test), doesn't affect `make build` |
+| AC7 behavior preservation + all other ACs | OK | All changes are non-breaking for valid inputs |
+
+---
+
+### Design-to-Code Accuracy Verification
+
+| Design Reference | Actual Code Location | Match |
+|-----------------|---------------------|-------|
+| `runner.go:31-36` — `ctx.AuthToken == ""` check | Line 34: `if ctx.AuthToken == ""` | **CORRECT** (minor line drift noted and fixed in review) |
+| `runner.go:37` — `len(opts.Target) == 0` | Line 37: `if len(opts.Target) == 0` | **CORRECT** |
+| `runner.go:44-60` — `Run()` returns `(int, error)` | Lines 44-60: three return paths | **CORRECT** |
+| `args.go:30-34` — ParseArgs no-args path | Lines 30-34: `len(args) == 0` through `return args[0], args[1:]` | **CORRECT** |
+| `cmd/exec.go:19-69` — exec with os.Exit calls | Lines 19-69: Run closure with multiple `os.Exit` | **CORRECT** |
+| `cmd/run.go:20-74` — run with os.Exit calls | Lines 20-74: Run closure with multiple `os.Exit` | **CORRECT** |
+| `config/config.go` respects `CCCTX_CONFIG_PATH` | Verified via grep: `os.Getenv("CCCTX_CONFIG_PATH")` | **CORRECT** |
+
+---
+
+### Issue Summary
+
+No issues found. All acceptance criteria are covered by the design with clear implementation paths, accurate code references, and consistent specifications.
+
+### Verdict
+
+**All user stories are satisfied by the design.** No blocking, high, or medium-severity issues remain. The design has undergone prior review rounds that resolved TDD ordering, test feasibility, ambiguous descriptions, line number drift, and minor inconsistencies. The behavioral coverage for all 7 acceptance criteria is complete and correct.

--- a/_bmad-output/implementation-artifacts/user-story-tests/3-2-add-model-override-flags-to-run-and-exec-user-story-test.md
+++ b/_bmad-output/implementation-artifacts/user-story-tests/3-2-add-model-override-flags-to-run-and-exec-user-story-test.md
@@ -1,0 +1,334 @@
+---
+tested_plan: _bmad-output/implementation-artifacts/3-2-add-model-override-flags-to-run-and-exec.md
+tested_stories: _bmad-output/implementation-artifacts/3-2-add-model-override-flags-to-run-and-exec.md
+tester: glm
+latest_round: 2
+test_rounds:
+  - round: 1
+    date: 2026-04-23
+  - round: 2
+    date: 2026-04-23
+---
+
+# User Story Test: 3-2-add-model-override-flags-to-run-and-exec
+
+Tested plan: `_bmad-output/implementation-artifacts/3-2-add-model-override-flags-to-run-and-exec.md`
+Tested stories: `_bmad-output/implementation-artifacts/3-2-add-model-override-flags-to-run-and-exec.md` (embedded AC1-AC10)
+
+## Round 1
+
+**Context:** Initial behavioral simulation of all acceptance criteria (AC1-AC10) against the design. The plan has been through 3 review rounds with all blocking/high issues resolved. This test focuses on user-facing behavior, not plan quality.
+
+### Story: AC1 — --model flag overrides config model
+
+**User story:** Given provider-A has `model = "claude-sonnet-4-6"` in config, `ccctx run provider-A --model claude-opus-4-7` sets `ANTHROPIC_MODEL=claude-opus-4-7` in the child process.
+
+**Simulated input:** User types `ccctx run provider-A --model claude-opus-4-7` in their terminal, where provider-A's config has `model = "claude-sonnet-4-6"`.
+
+**Expected behavior:** The child `claude` process receives `ANTHROPIC_MODEL=claude-opus-4-7` (CLI flag value), not `claude-sonnet-4-6` (config value).
+
+**Traced behavior:**
+1. Cobra's `DisableFlagParsing: true` passes raw args `["provider-A", "--model", "claude-opus-4-7"]` to Run closure
+2. `WantsHelp(args)` → false (no `--help`/`-h`)
+3. `runRun(args)` called
+4. `ExtractFlags(args)`: scans all args (no `--` separator), finds `--model` at index 1 with value `"claude-opus-4-7"` at index 2 → model="claude-opus-4-7", remaining=["provider-A"]
+5. `ParseArgs(["provider-A"])` → provider="provider-A", targetArgs=[], useTUI=false
+6. `LookPath("claude")` → finds claude binary
+7. target = ["claude"]
+8. `New(Options{ContextName: "provider-A", Target: ["claude"], Model: "claude-opus-4-7"})`
+9. In `buildEnv(ctx, opts)`: opts.Model="claude-opus-4-7" (non-empty) → `model = "claude-opus-4-7"` → appends `ANTHROPIC_MODEL=claude-opus-4-7`
+10. Child process launched with `ANTHROPIC_MODEL=claude-opus-4-7`
+
+**Result:** PASS
+
+---
+
+### Story: AC2 — --model flag sets model when config has none
+
+**User story:** Given provider-A has no `model` configured, `ccctx exec provider-A --model claude-opus-4-7 -- env | grep ANTHROPIC_MODEL` outputs `ANTHROPIC_MODEL=claude-opus-4-7`.
+
+**Simulated input:** User types `ccctx exec provider-A --model claude-opus-4-7 -- env | grep ANTHROPIC_MODEL` in their terminal. The outer shell handles the `|` pipe operator, so ccctx receives args `["provider-A", "--model", "claude-opus-4-7", "--", "env"]`.
+
+**Expected behavior:** `env` runs with `ANTHROPIC_MODEL=claude-opus-4-7` set in its environment, and `grep ANTHROPIC_MODEL` filters to show that line.
+
+**Traced behavior:**
+1. `DisableFlagParsing: true` → raw args to Run closure
+2. `WantsHelp(args)` → false
+3. `execRun(args)` called
+4. `ExtractFlags(["provider-A", "--model", "claude-opus-4-7", "--", "env"])`: sepIdx=3, preSep=["provider-A", "--model", "claude-opus-4-7"]. Scans pre-sep: index 0 → "provider-A" (remaining), index 1 → `--model` with value "claude-opus-4-7". model="claude-opus-4-7", remaining=["provider-A", "--", "env"]
+5. `ParseArgs(["provider-A", "--", "env"])`: separatorIndex=1, provider="provider-A", targetArgs=["env"], useTUI=false
+6. targetArgs=["env"] (non-empty) → no $SHELL fallback
+7. `New(Options{ContextName: "provider-A", Target: ["env"], Model: "claude-opus-4-7"})`
+8. In `buildEnv(ctx, opts)`: ctx.Model="" (not configured), opts.Model="claude-opus-4-7" → model="claude-opus-4-7" → `ANTHROPIC_MODEL=claude-opus-4-7`
+9. `exec.Command("env")` launched with ANTHROPIC_MODEL=claude-opus-4-7 in env
+10. `env` prints all env vars, outer shell pipes to `grep ANTHROPIC_MODEL` → outputs `ANTHROPIC_MODEL=claude-opus-4-7`
+
+**Result:** PASS
+
+---
+
+### Story: AC3 — --small-fast-model flag works
+
+**User story:** Given provider-A has `small_fast_model = "claude-haiku-4-5"`, `ccctx run provider-A --small-fast-model claude-sonnet-4-6` sets `ANTHROPIC_SMALL_FAST_MODEL=claude-sonnet-4-6`.
+
+**Simulated input:** User types `ccctx run provider-A --small-fast-model claude-sonnet-4-6`.
+
+**Expected behavior:** Child process receives `ANTHROPIC_SMALL_FAST_MODEL=claude-sonnet-4-6` (CLI flag), not `claude-haiku-4-5` (config).
+
+**Traced behavior:**
+1. `ExtractFlags(["provider-A", "--small-fast-model", "claude-sonnet-4-6"])`: finds `--small-fast-model` at index 1, value "claude-sonnet-4-6" → smallFastModel="claude-sonnet-4-6", remaining=["provider-A"]
+2. `ParseArgs(["provider-A"])` → provider="provider-A"
+3. `buildEnv(ctx, opts)`: opts.SmallFastModel="claude-sonnet-4-6" (non-empty) → sfm="claude-sonnet-4-6" → `ANTHROPIC_SMALL_FAST_MODEL=claude-sonnet-4-6`
+
+**Result:** PASS
+
+---
+
+### Story: AC4 — CLI flags take priority over config
+
+**User story:** When both CLI flag and config value exist, CLI flag wins. Priority chain: `Options.Model > ctx.Model > omit`.
+
+**Simulated input:** User types `ccctx run provider-A --model claude-opus-4-7 --small-fast-model claude-sonnet-4-6`, where provider-A config has `model = "claude-sonnet-4-6"` and `small_fast_model = "claude-haiku-4-5"`.
+
+**Expected behavior:** `ANTHROPIC_MODEL=claude-opus-4-7` and `ANTHROPIC_SMALL_FAST_MODEL=claude-sonnet-4-6` (both CLI values win).
+
+**Traced behavior:**
+1. `ExtractFlags`: model="claude-opus-4-7", smallFastModel="claude-sonnet-4-6", remaining=["provider-A"]
+2. `buildEnv(ctx, opts)`:
+   - model = opts.Model = "claude-opus-4-7" (non-empty, skips ctx.Model="claude-sonnet-4-6") → `ANTHROPIC_MODEL=claude-opus-4-7`
+   - sfm = opts.SmallFastModel = "claude-sonnet-4-6" (non-empty, skips ctx.SmallFastModel="claude-haiku-4-5") → `ANTHROPIC_SMALL_FAST_MODEL=claude-sonnet-4-6`
+
+**Additional traces — all priority combinations:**
+
+| opts.Model | ctx.Model | Result |
+|------------|-----------|--------|
+| "opus" | "sonnet" | ANTHROPIC_MODEL=opus |
+| "opus" | "" | ANTHROPIC_MODEL=opus |
+| "" | "sonnet" | ANTHROPIC_MODEL=sonnet |
+| "" | "" | (no ANTHROPIC_MODEL injected) |
+
+Same pattern verified for SmallFastModel.
+
+**Result:** PASS — all priority combinations produce correct behavior.
+
+---
+
+### Story: AC5 — No flags = config values used
+
+**User story:** When no flags specified, config file values are used (existing behavior unchanged).
+
+**Simulated input:** User types `ccctx run provider-A`, where provider-A has `model = "claude-sonnet-4-6"` and `small_fast_model = "claude-haiku-4-5"`.
+
+**Expected behavior:** Same behavior as before this story was implemented — config values are used.
+
+**Traced behavior:**
+1. `ExtractFlags(["provider-A"])`: no `--model`/`--small-fast-model` found → model="", smallFastModel="", remaining=["provider-A"]
+2. `ParseArgs(["provider-A"])` → provider="provider-A"
+3. `buildEnv(ctx, opts)`: opts.Model="" → falls through to ctx.Model="claude-sonnet-4-6" → `ANTHROPIC_MODEL=claude-sonnet-4-6`. Same for SmallFastModel.
+
+**Result:** PASS — existing behavior preserved. Also verified that existing tests `TestBuildEnv`, `TestBuildEnv_SkipsEmptyOptional`, `TestBuildEnv_InjectionOrder` continue to pass because they use `Options{}` (zero values), which triggers the ctx fallback path.
+
+---
+
+### Story: AC6 — Flags available on both commands
+
+**User story:** `--model` and `--small-fast-model` work identically on both `run` and `exec`.
+
+**Simulated input:** User runs both commands with model flags:
+- `ccctx run provider-A --model claude-opus-4-7`
+- `ccctx exec provider-A --model claude-opus-4-7`
+
+**Expected behavior:** Both commands extract the flag and set `ANTHROPIC_MODEL=claude-opus-4-7`.
+
+**Traced behavior:**
+
+**run command:**
+1. RunCmd has `DisableFlagParsing: true`
+2. Run closure checks `WantsHelp(args)` → false
+3. `runRun(args)` calls `ExtractFlags` → `ParseArgs` → `New(Options{Model: "claude-opus-4-7", ...})`
+4. `buildEnv` uses opts.Model → `ANTHROPIC_MODEL=claude-opus-4-7`
+
+**exec command:**
+1. ExecCmd has `DisableFlagParsing: true`
+2. Run closure checks `WantsHelp(args)` → false
+3. `execRun(args)` calls `ExtractFlags` → `ParseArgs` → `New(Options{Model: "claude-opus-4-7", ...})`
+4. `buildEnv` uses opts.Model → `ANTHROPIC_MODEL=claude-opus-4-7`
+
+Both follow the identical pattern: ExtractFlags → ParseArgs → Options → buildEnv. The flag handling is shared via `runner.ExtractFlags` (not duplicated per command).
+
+**Result:** PASS
+
+---
+
+### Story: AC7 — --model with TUI mode
+
+**User story:** `ccctx run --model claude-opus-4-7` (no provider) opens TUI selector, and the selected provider runs with the overridden model.
+
+**Simulated input:** User types `ccctx run --model claude-opus-4-7` (no provider specified).
+
+**Expected behavior:** TUI selector appears, user selects a provider, claude runs with `ANTHROPIC_MODEL=claude-opus-4-7`.
+
+**Traced behavior:**
+1. `WantsHelp(["--model", "claude-opus-4-7"])` → false (no `--help`/`-h`)
+2. `runRun(["--model", "claude-opus-4-7"])`
+3. `ExtractFlags(["--model", "claude-opus-4-7"])`: model="claude-opus-4-7", remaining=[]
+4. `ParseArgs([])` → provider="", targetArgs=[], useTUI=true
+5. TUI flow: `config.ListContexts()` → `ui.RunContextSelector(contexts)` → user selects "provider-A"
+6. `LookPath("claude")` → finds claude binary
+7. `New(Options{ContextName: "provider-A", Target: ["claude"], Model: "claude-opus-4-7"})`
+8. `buildEnv(ctx, opts)`: opts.Model="claude-opus-4-7" → `ANTHROPIC_MODEL=claude-opus-4-7`
+
+Key insight: `model` is captured before `ParseArgs` and passed to `Options` after TUI selection. The flag value flows through the TUI path correctly because `ExtractFlags` runs at the top of `runRun`, before the TUI branch.
+
+**Result:** PASS
+
+---
+
+### Story: AC8 — -- separator not consumed by flag parsing
+
+**User story:** `ccctx exec provider-A --model claude-opus-4-7 -- env | grep ANTHROPIC_MODEL` correctly forwards `env | grep ANTHROPIC_MODEL` as the target command.
+
+**Simulated input:** User types `ccctx exec provider-A --model claude-opus-4-7 -- env | grep ANTHROPIC_MODEL`. The outer shell handles piping, so ccctx receives args `["provider-A", "--model", "claude-opus-4-7", "--", "env"]`.
+
+**Expected behavior:** `--model` is extracted, `--` separator is preserved for `ParseArgs`, and `env` becomes the target command.
+
+**Traced behavior:**
+1. `ExtractFlags(["provider-A", "--model", "claude-opus-4-7", "--", "env"])`:
+   - sepIdx = 3 (the `--` at index 3)
+   - preSep = ["provider-A", "--model", "claude-opus-4-7"]
+   - Scan pre-sep: "provider-A" → remaining; `--model` at index 1 → extract with value "claude-opus-4-7"
+   - remaining = ["provider-A"]; post-separator = ["--", "env"]
+   - Full remaining = ["provider-A", "--", "env"]; model = "claude-opus-4-7"
+2. `ParseArgs(["provider-A", "--", "env"])`:
+   - separatorIndex = 1 (the `--`)
+   - provider = "provider-A", targetArgs = ["env"]
+3. `exec.Command("env")` launched with correct env vars
+
+**Additional edge case — flag after `--`:**
+`ccctx run provider-A -- --model foo`:
+- ExtractFlags: sepIdx=1, preSep=["provider-A"]. No flags in pre-sep.
+- remaining = ["provider-A", "--", "--model", "foo"]
+- ParseArgs: provider="provider-A", targetArgs=["--model", "foo"]
+- `--model foo` forwarded to claude, not extracted.
+
+**Result:** PASS — `--` separator handling is correct in both directions.
+
+---
+
+### Story: AC9 — All existing tests pass
+
+**User story:** `go test ./...` passes, `go vet ./...` clean, `make build` succeeds.
+
+**Simulated input:** Developer runs `go test ./...` after implementing all tasks.
+
+**Expected behavior:** All tests pass without modification (except the one explicitly updated test).
+
+**Traced behavior:** Traced through every existing test case:
+
+**internal/runner/args_test.go — TestParseArgs:** ParseArgs is unchanged. All 11 cases pass. ✓
+
+**internal/runner/runner_test.go:**
+- `TestBuildEnv`: Uses `Options{}` (zero Model/SmallFastModel). After priority chain: opts.Model="" → falls through to ctx.Model="claude-sonnet-4-6". Same result as current code. ✓
+- `TestBuildEnv_SkipsEmptyOptional`: ctx.Model="" and ctx.SmallFastModel="". opts.Model="" and opts.SmallFastModel="". Priority chain: both empty → no injection. Same result. ✓
+- `TestBuildEnv_InjectionOrder`: Priority chain preserves BASE_URL → AUTH_TOKEN → MODEL → SMALL_FAST_MODEL order. ✓
+- `TestValidateURL`: Unchanged. ✓
+
+**cmd/run_test.go — TestRunRun:**
+- "ParseArgs error - flag-like arg": Updated in Task 5 to use `--unknown-flag foo`. ExtractFlags doesn't extract it → ParseArgs rejects it. ✓
+- "context not found": `ExtractFlags(["nonexistent"])` → remaining=["nonexistent"] → ParseArgs → provider="nonexistent" → GetContext fails. ✓
+- "claude not found in PATH": `ExtractFlags(["test"])` → remaining=["test"] → ParseArgs → provider="test" → LookPath fails. ✓
+- "success - provider found and claude found": `ExtractFlags(["test"])` → remaining=["test"] → ParseArgs → provider="test" → LookPath finds mock → success. ✓
+- "success - claude exits with non-zero code": Same pattern as above. ✓
+- "missing base_url", "invalid base_url", "missing auth_token": All work through the same ExtractFlags → ParseArgs → GetContext path. ✓
+- "success - provider with forwarded args after separator": `ExtractFlags(["test", "--", "--model", "foo"])` → sepIdx=1, preSep=["test"], no flags extracted → remaining=["test", "--", "--model", "foo"] → ParseArgs → provider="test", targetArgs=["--model", "foo"]. ✓
+
+All existing tests pass. ✓
+
+**Result:** PASS
+
+---
+
+### Story: AC10 — New table-driven tests
+
+**User story:** Tests cover flag extraction, priority chain, and integration with both commands.
+
+**Simulated input:** Developer runs the new tests.
+
+**Expected behavior:** Tests cover ExtractFlags (11 cases), WantsHelp (6 cases), buildEnv priority (7+ cases), run integration (4 cases), exec integration (3 cases).
+
+**Traced behavior:** Verified coverage against acceptance criteria:
+
+| Test Location | What It Tests | Coverage |
+|---------------|---------------|----------|
+| args_test.go: ExtractFlags | 11 cases including no flags, both flags, separator, errors, edge cases | AC8, AC10 |
+| args_test.go: WantsHelp | 6 cases: --help, -h, after --, empty, with provider | Prevents --help regression |
+| runner_test.go: buildEnv | Priority chain for Model and SmallFastModel, all 4 combinations each | AC1-AC5, AC10 |
+| run_test.go: integration | --model with provider, --model with -- separator, --model without value, both flags | AC6, AC7, AC8, AC10 |
+| exec_test.go: integration | --model with provider (shell mock), --model without value, --model with explicit target | AC6, AC10 |
+
+**Result:** PASS — comprehensive test coverage for all acceptance criteria.
+
+---
+
+### Issue Summary
+
+| # | Severity | Story | Issue |
+|---|----------|-------|-------|
+| 1 | MEDIUM | AC10 (Task 6) | Exec mock setup omits SHELL env var for no-target-args tests |
+
+### Issues
+
+#### 1. [MEDIUM] Exec mock setup for no-target-args tests doesn't mention setting SHELL
+
+- **User story expects:** AC10 tests verify env var propagation end-to-end through the actual `exec.Command` path.
+- **Design says:** "Env-Capturing Mock Pattern" Dev Notes step 4: "Set `PATH` to temp dir containing the mock. Mock naming rules: ...exec tests with no target args: mock named as `$SHELL` basename (e.g., `bash`) — exec falls back to `$SHELL`."
+- **Gap/Mismatch/Ambiguity:** The instructions say to name the mock after `$SHELL`'s basename and add it to PATH, but don't mention setting `SHELL` itself. Without setting `SHELL`, the exec code does `shell := os.Getenv("SHELL")` → gets the real shell path (e.g., `/bin/bash`), then `exec.Command("/bin/bash")` runs the real shell, not the mock. PATH lookup is never triggered because the target contains a path separator.
+- **Suggested fix:** Add to step 4: "For exec tests with no target args, also set `SHELL` to the mock's full path: `t.Setenv("SHELL", filepath.Join(tmpDir, "bash"))`." Alternatively, set `SHELL` to just `"bash"` (no path separator) so `exec.Command("bash")` does PATH lookup — both approaches work, but the full path approach is more representative of production behavior.
+
+---
+
+### Verification Summary
+
+| AC | Description | Result | Notes |
+|----|-------------|--------|-------|
+| AC1 | --model overrides config model | PASS | Priority chain: opts.Model > ctx.Model |
+| AC2 | --model sets model when config has none | PASS | -- separator preserved for ParseArgs |
+| AC3 | --small-fast-model works | PASS | Same mechanism as --model |
+| AC4 | CLI flags take priority over config | PASS | All 4 priority combinations verified |
+| AC5 | No flags = config values used | PASS | Existing behavior preserved, existing tests unaffected |
+| AC6 | Flags on both commands | PASS | Shared ExtractFlags, identical pattern |
+| AC7 | --model with TUI mode | PASS | Flag captured before ParseArgs, passed after TUI selection |
+| AC8 | -- separator not consumed | PASS | ExtractFlags scans only before --, preserves separator |
+| AC9 | All existing tests pass | PASS | Every existing test traced through updated code |
+| AC10 | New table-driven tests | PASS (with 1 MEDIUM issue) | Mock setup gap for exec no-target-args tests |
+
+### Verdict
+
+All 10 user stories are satisfied by the design. 9 of 10 pass cleanly. One medium-severity issue: the exec mock setup instructions for no-target-args tests don't mention setting the `SHELL` env var, which is required for the mock to actually be invoked (without it, `exec.Command` runs the real shell via the full `$SHELL` path, bypassing the mock). This is not a design flaw — the feature behavior is correct — but the test implementation instructions have a gap that the executor will need to resolve.
+
+---
+
+## Round 2
+
+**Date:** 2026-04-23
+**Context:** Response to Round 1. Addressing the single MEDIUM issue found during initial testing.
+
+### Round 1 Issue Resolution
+
+| # | Severity | Issue | Status | Evidence |
+|---|----------|-------|--------|----------|
+| 1 | MEDIUM | Exec mock setup for no-target-args tests doesn't mention setting `SHELL` env var | ✅ Fixed | Plan "Env-Capturing Mock Pattern" step 4 updated to include `t.Setenv("SHELL", filepath.Join(tmpDir, "bash"))` with explanation of why it's needed |
+
+### Resolution Detail
+
+**Issue #1 — SHELL env var for exec mock:**
+
+The plan's "Env-Capturing Mock Pattern" (Dev Notes step 4) instructed the executor to name the mock after `$SHELL`'s basename (e.g., `bash`) and place it in PATH. However, without explicitly setting `SHELL` in the test environment, `os.Getenv("SHELL")` returns the real shell path (e.g., `/bin/bash`), which contains a path separator. Go's `exec.Command("/bin/bash")` resolves the full path directly — it never triggers PATH lookup, so the mock is bypassed entirely.
+
+**Fix applied:** Added `t.Setenv("SHELL", filepath.Join(tmpDir, "bash"))` to the exec no-target-args mock setup instructions, with a note explaining the root cause: without setting `SHELL`, the real shell path bypasses the mock.
+
+This is a test-instruction gap only — the feature code itself is correct.
+
+### Updated Verdict
+
+All 10 user stories pass cleanly. The single MEDIUM issue has been resolved in the plan. The design is ready for implementation.

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -12,16 +12,29 @@ import (
 )
 
 var ExecCmd = &cobra.Command{
-	Use:   "exec [context] [-- command...]",
-	Short: "Execute a command or launch a shell with a context",
-	Long:  "Execute a command or launch a shell with the specified context. If no command is given, launches $SHELL. If no context is given, opens the interactive selector.",
-	Args:  cobra.ArbitraryArgs,
+	Use:                "exec [context] [-- command...]",
+	Short:              "Execute a command or launch a shell with a context",
+	Long:               "Execute a command or launch a shell with the specified context. If no command is given, launches $SHELL. If no context is given, opens the interactive selector.",
+	Args:               cobra.ArbitraryArgs,
+	DisableFlagParsing: true,
 	Run: func(cmd *cobra.Command, args []string) {
+		if runner.WantsHelp(args) {
+			if err := cmd.Help(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
+			return
+		}
 		os.Exit(execRun(args))
 	},
 }
 
 func execRun(args []string) int {
+	model, smallFastModel, args, err := runner.ExtractFlags(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
 	provider, targetArgs, useTUI, err := runner.ParseArgs(args)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -58,7 +71,7 @@ func execRun(args []string) int {
 		targetArgs = []string{shell}
 	}
 
-	opts := runner.Options{ContextName: provider, Target: targetArgs}
+	opts := runner.Options{ContextName: provider, Target: targetArgs, Model: model, SmallFastModel: smallFastModel}
 	r, err := runner.New(opts)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -17,54 +17,58 @@ var ExecCmd = &cobra.Command{
 	Long:  "Execute a command or launch a shell with the specified context. If no command is given, launches $SHELL. If no context is given, opens the interactive selector.",
 	Args:  cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		provider, targetArgs, useTUI, err := runner.ParseArgs(args)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-
-		if useTUI {
-			contexts, err := config.ListContexts()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-			if len(contexts) == 0 {
-				fmt.Fprintf(os.Stderr, "Error: no contexts found\n")
-				os.Exit(1)
-			}
-			provider, err = ui.RunContextSelector(contexts)
-			if err != nil {
-				if errors.Is(err, ui.ErrCancelled) {
-					fmt.Fprintln(os.Stderr, "Operation cancelled.")
-					os.Exit(1)
-				}
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-		}
-
-		if len(targetArgs) == 0 {
-			shell := os.Getenv("SHELL")
-			if shell == "" {
-				fmt.Fprintf(os.Stderr, "Error: SHELL environment variable not set\n")
-				os.Exit(1)
-			}
-			targetArgs = []string{shell}
-		}
-
-		opts := runner.Options{ContextName: provider, Target: targetArgs}
-		r, err := runner.New(opts)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-
-		exitCode, err := r.Run()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-		os.Exit(exitCode)
+		os.Exit(execRun(args))
 	},
+}
+
+func execRun(args []string) int {
+	provider, targetArgs, useTUI, err := runner.ParseArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	if useTUI {
+		contexts, err := config.ListContexts()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		if len(contexts) == 0 {
+			fmt.Fprintf(os.Stderr, "Error: no contexts found\n")
+			return 1
+		}
+		provider, err = ui.RunContextSelector(contexts)
+		if err != nil {
+			if errors.Is(err, ui.ErrCancelled) {
+				fmt.Fprintln(os.Stderr, "Operation cancelled.")
+				return 1
+			}
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+	}
+
+	if len(targetArgs) == 0 {
+		shell := os.Getenv("SHELL")
+		if shell == "" {
+			fmt.Fprintf(os.Stderr, "Error: SHELL environment variable not set\n")
+			return 1
+		}
+		targetArgs = []string{shell}
+	}
+
+	opts := runner.Options{ContextName: provider, Target: targetArgs}
+	r, err := runner.New(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	exitCode, err := r.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	return exitCode
 }

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecRun_ModelFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		configTOML string
+		envSetup   func(t *testing.T, mockDir string, outputFile string)
+		wantCode   int
+		wantModel  string
+		wantSFM    string
+	}{
+		{
+			name: "--model flag sets ANTHROPIC_MODEL via shell",
+			args: []string{"--model", "claude-opus-4-7", "test"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode:  0,
+			wantModel: "claude-opus-4-7",
+		},
+		{
+			name: "--model without value returns error",
+			args: []string{"--model"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode: 1,
+		},
+		{
+			name: "--small-fast-model without value returns error",
+			args: []string{"--small-fast-model"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode: 1,
+		},
+		{
+			name: "provider with --model and explicit target command",
+			args: []string{"test", "--model", "claude-opus-4-7", "--", "env"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode:  0,
+			wantModel: "claude-opus-4-7",
+		},
+		{
+			name: "--small-fast-model flag sets ANTHROPIC_SMALL_FAST_MODEL via shell",
+			args: []string{"--small-fast-model", "claude-sonnet-4-6", "test"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode: 0,
+			wantSFM:  "claude-sonnet-4-6",
+		},
+		{
+			name: "both flags set both env vars via shell",
+			args: []string{"test", "--model", "claude-opus-4-7", "--small-fast-model", "claude-sonnet-4-6"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode:  0,
+			wantModel: "claude-opus-4-7",
+			wantSFM:   "claude-sonnet-4-6",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.toml")
+			err := os.WriteFile(configPath, []byte(tt.configTOML), 0600)
+			require.NoError(t, err)
+			t.Setenv("CCCTX_CONFIG_PATH", configPath)
+
+			outputFile := filepath.Join(t.TempDir(), "mock_output")
+			t.Setenv("MOCK_OUTPUT_FILE", outputFile)
+
+			mockDir := t.TempDir()
+			mockScript := []byte("#!/bin/sh\necho \"$ANTHROPIC_MODEL\" > \"$MOCK_OUTPUT_FILE\"\necho \"$ANTHROPIC_SMALL_FAST_MODEL\" >> \"$MOCK_OUTPUT_FILE\"\nexit 0")
+
+			// Determine mock name based on whether args include explicit target after --
+			hasExplicitTarget := false
+			for i, a := range tt.args {
+				if a == "--" && i+1 < len(tt.args) {
+					hasExplicitTarget = true
+					break
+				}
+			}
+
+			if hasExplicitTarget {
+				// Find the first target arg after --
+				for i, a := range tt.args {
+					if a == "--" && i+1 < len(tt.args) {
+						mockName := tt.args[i+1]
+						err = os.WriteFile(filepath.Join(mockDir, mockName), mockScript, 0755)
+						require.NoError(t, err)
+						break
+					}
+				}
+			} else {
+				// exec falls back to $SHELL — mock as "bash"
+				err = os.WriteFile(filepath.Join(mockDir, "bash"), mockScript, 0755)
+				require.NoError(t, err)
+				t.Setenv("SHELL", filepath.Join(mockDir, "bash"))
+			}
+
+			t.Setenv("PATH", mockDir)
+
+			code := execRun(tt.args)
+			assert.Equal(t, tt.wantCode, code)
+
+			if tt.wantCode == 0 {
+				data, err := os.ReadFile(outputFile)
+				require.NoError(t, err)
+				lines := strings.Split(string(data), "\n")
+				if tt.wantModel != "" {
+					require.GreaterOrEqual(t, len(lines), 1, "mock did not write ANTHROPIC_MODEL")
+					assert.Equal(t, tt.wantModel, lines[0])
+				}
+				if tt.wantSFM != "" {
+					require.GreaterOrEqual(t, len(lines), 2, "mock did not write ANTHROPIC_SMALL_FAST_MODEL")
+					assert.Equal(t, tt.wantSFM, lines[1])
+				}
+			}
+		})
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,16 +13,29 @@ import (
 )
 
 var RunCmd = &cobra.Command{
-	Use:   "run [context] [-- claude-args...]",
-	Short: "Run claude with a context",
-	Long:  "Run claude with the specified context or interactively select one. Arguments after '--' are passed to claude.",
-	Args:  cobra.ArbitraryArgs,
+	Use:                "run [context] [-- claude-args...]",
+	Short:              "Run claude with a context",
+	Long:               "Run claude with the specified context or interactively select one. Arguments after '--' are passed to claude.",
+	Args:               cobra.ArbitraryArgs,
+	DisableFlagParsing: true,
 	Run: func(cmd *cobra.Command, args []string) {
+		if runner.WantsHelp(args) {
+			if err := cmd.Help(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			}
+			return
+		}
 		os.Exit(runRun(args))
 	},
 }
 
 func runRun(args []string) int {
+	model, smallFastModel, args, err := runner.ExtractFlags(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
 	provider, targetArgs, useTUI, err := runner.ParseArgs(args)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -61,8 +74,10 @@ func runRun(args []string) int {
 	target := append([]string{claudePath}, targetArgs...)
 
 	r, err := runner.New(runner.Options{
-		ContextName: provider,
-		Target:      target,
+		ContextName:    provider,
+		Target:         target,
+		Model:          model,
+		SmallFastModel: smallFastModel,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,57 +18,61 @@ var RunCmd = &cobra.Command{
 	Long:  "Run claude with the specified context or interactively select one. Arguments after '--' are passed to claude.",
 	Args:  cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		provider, targetArgs, useTUI, err := runner.ParseArgs(args)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-
-		if useTUI {
-			contexts, err := config.ListContexts()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-
-			if len(contexts) == 0 {
-				fmt.Fprintf(os.Stderr, "Error: no contexts found\n")
-				os.Exit(1)
-			}
-
-			provider, err = ui.RunContextSelector(contexts)
-			if err != nil {
-				if errors.Is(err, ui.ErrCancelled) {
-					fmt.Fprintln(os.Stderr, "Operation cancelled.")
-					os.Exit(1)
-				}
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
-			}
-		}
-
-		claudePath, err := exec.LookPath("claude")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: claude not found in PATH\n")
-			os.Exit(1)
-		}
-
-		target := append([]string{claudePath}, targetArgs...)
-
-		r, err := runner.New(runner.Options{
-			ContextName: provider,
-			Target:      target,
-		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-
-		exitCode, err := r.Run()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-		os.Exit(exitCode)
+		os.Exit(runRun(args))
 	},
+}
+
+func runRun(args []string) int {
+	provider, targetArgs, useTUI, err := runner.ParseArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	if useTUI {
+		contexts, err := config.ListContexts()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+
+		if len(contexts) == 0 {
+			fmt.Fprintf(os.Stderr, "Error: no contexts found\n")
+			return 1
+		}
+
+		provider, err = ui.RunContextSelector(contexts)
+		if err != nil {
+			if errors.Is(err, ui.ErrCancelled) {
+				fmt.Fprintln(os.Stderr, "Operation cancelled.")
+				return 1
+			}
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+	}
+
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: claude not found in PATH\n")
+		return 1
+	}
+
+	target := append([]string{claudePath}, targetArgs...)
+
+	r, err := runner.New(runner.Options{
+		ContextName: provider,
+		Target:      target,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	exitCode, err := r.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	return exitCode
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,29 +20,29 @@ func TestRunRun(t *testing.T) {
 	}{
 		{
 			name: "ParseArgs error - flag-like arg",
-			args: []string{"--model", "foo"},
+			args: []string{"--unknown-flag", "foo"},
 			configTOML: `[context.test]
-base_url = "https://api.example.com"
-auth_token = "test-token"
-`,
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
 			wantCode: 1,
 		},
 		{
 			name: "context not found",
 			args: []string{"nonexistent"},
 			configTOML: `[context.test]
-base_url = "https://api.example.com"
-auth_token = "test-token"
-`,
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
 			wantCode: 1,
 		},
 		{
 			name: "claude not found in PATH",
 			args: []string{"test"},
 			configTOML: `[context.test]
-base_url = "https://api.example.com"
-auth_token = "test-token"
-`,
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
 			envSetup: func(t *testing.T) {
 				t.Setenv("PATH", "/nonexistent")
 			},
@@ -51,9 +52,9 @@ auth_token = "test-token"
 			name: "success - provider found and claude found",
 			args: []string{"test"},
 			configTOML: `[context.test]
-base_url = "https://api.example.com"
-auth_token = "test-token"
-`,
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
 			envSetup: func(t *testing.T) {
 				tmpDir := t.TempDir()
 				claudePath := filepath.Join(tmpDir, "claude")
@@ -67,9 +68,9 @@ auth_token = "test-token"
 			name: "success - claude exits with non-zero code",
 			args: []string{"test"},
 			configTOML: `[context.test]
-base_url = "https://api.example.com"
-auth_token = "test-token"
-`,
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
 			envSetup: func(t *testing.T) {
 				tmpDir := t.TempDir()
 				claudePath := filepath.Join(tmpDir, "claude")
@@ -83,34 +84,34 @@ auth_token = "test-token"
 			name: "missing base_url in context",
 			args: []string{"badctx"},
 			configTOML: `[context.badctx]
-auth_token = "test-token"
-`,
+	auth_token = "test-token"
+	`,
 			wantCode: 1,
 		},
 		{
 			name: "invalid base_url format",
 			args: []string{"badurl"},
 			configTOML: `[context.badurl]
-base_url = "not-a-valid-url"
-auth_token = "test-token"
-`,
+	base_url = "not-a-valid-url"
+	auth_token = "test-token"
+	`,
 			wantCode: 1,
 		},
 		{
 			name: "missing auth_token in context",
 			args: []string{"noauthtoken"},
 			configTOML: `[context.noauthtoken]
-base_url = "https://api.example.com"
-`,
+	base_url = "https://api.example.com"
+	`,
 			wantCode: 1,
 		},
 		{
 			name: "success - provider with forwarded args after separator",
 			args: []string{"test", "--", "--model", "foo"},
 			configTOML: `[context.test]
-base_url = "https://api.example.com"
-auth_token = "test-token"
-`,
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
 			envSetup: func(t *testing.T) {
 				tmpDir := t.TempDir()
 				claudePath := filepath.Join(tmpDir, "claude")
@@ -136,6 +137,103 @@ auth_token = "test-token"
 
 			code := runRun(tt.args)
 			assert.Equal(t, tt.wantCode, code)
+		})
+	}
+}
+
+func TestRunRun_ModelFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		configTOML string
+		wantCode   int
+		wantModel  string
+		wantSFM    string
+	}{
+		{
+			name: "--model flag sets ANTHROPIC_MODEL",
+			args: []string{"--model", "claude-opus-4-7", "test"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode:  0,
+			wantModel: "claude-opus-4-7",
+		},
+		{
+			name: "--model with separator forwards args",
+			args: []string{"--model", "claude-opus-4-7", "test", "--", "--help"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode:  0,
+			wantModel: "claude-opus-4-7",
+		},
+		{
+			name: "--model without value returns error",
+			args: []string{"--model"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode: 1,
+		},
+		{
+			name: "--small-fast-model without value returns error",
+			args: []string{"--small-fast-model"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode: 1,
+		},
+		{
+			name: "both flags set both env vars",
+			args: []string{"test", "--model", "claude-opus-4-7", "--small-fast-model", "claude-sonnet-4-6"},
+			configTOML: `[context.test]
+	base_url = "https://api.example.com"
+	auth_token = "test-token"
+	`,
+			wantCode:  0,
+			wantModel: "claude-opus-4-7",
+			wantSFM:   "claude-sonnet-4-6",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.toml")
+			err := os.WriteFile(configPath, []byte(tt.configTOML), 0600)
+			require.NoError(t, err)
+			t.Setenv("CCCTX_CONFIG_PATH", configPath)
+
+			outputFile := filepath.Join(t.TempDir(), "mock_output")
+			t.Setenv("MOCK_OUTPUT_FILE", outputFile)
+
+			mockDir := t.TempDir()
+			claudePath := filepath.Join(mockDir, "claude")
+			err = os.WriteFile(claudePath, []byte("#!/bin/sh\necho \"$ANTHROPIC_MODEL\" > \"$MOCK_OUTPUT_FILE\"\necho \"$ANTHROPIC_SMALL_FAST_MODEL\" >> \"$MOCK_OUTPUT_FILE\"\nexit 0"), 0755)
+			require.NoError(t, err)
+			t.Setenv("PATH", mockDir)
+
+			code := runRun(tt.args)
+			assert.Equal(t, tt.wantCode, code)
+
+			if tt.wantCode == 0 {
+				data, err := os.ReadFile(outputFile)
+				require.NoError(t, err)
+				lines := strings.Split(string(data), "\n")
+				if tt.wantModel != "" {
+					require.GreaterOrEqual(t, len(lines), 1, "mock did not write ANTHROPIC_MODEL")
+					assert.Equal(t, tt.wantModel, lines[0])
+				}
+				if tt.wantSFM != "" {
+					require.GreaterOrEqual(t, len(lines), 2, "mock did not write ANTHROPIC_SMALL_FAST_MODEL")
+					assert.Equal(t, tt.wantSFM, lines[1])
+				}
+			}
 		})
 	}
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		configTOML string
+		envSetup   func(t *testing.T)
+		wantCode   int
+	}{
+		{
+			name: "ParseArgs error - flag-like arg",
+			args: []string{"--model", "foo"},
+			configTOML: `[context.test]
+base_url = "https://api.example.com"
+auth_token = "test-token"
+`,
+			wantCode: 1,
+		},
+		{
+			name: "context not found",
+			args: []string{"nonexistent"},
+			configTOML: `[context.test]
+base_url = "https://api.example.com"
+auth_token = "test-token"
+`,
+			wantCode: 1,
+		},
+		{
+			name: "claude not found in PATH",
+			args: []string{"test"},
+			configTOML: `[context.test]
+base_url = "https://api.example.com"
+auth_token = "test-token"
+`,
+			envSetup: func(t *testing.T) {
+				t.Setenv("PATH", "/nonexistent")
+			},
+			wantCode: 1,
+		},
+		{
+			name: "success - provider found and claude found",
+			args: []string{"test"},
+			configTOML: `[context.test]
+base_url = "https://api.example.com"
+auth_token = "test-token"
+`,
+			envSetup: func(t *testing.T) {
+				tmpDir := t.TempDir()
+				claudePath := filepath.Join(tmpDir, "claude")
+				err := os.WriteFile(claudePath, []byte("#!/bin/sh\nexit 0"), 0755)
+				require.NoError(t, err)
+				t.Setenv("PATH", tmpDir)
+			},
+			wantCode: 0,
+		},
+		{
+			name: "success - claude exits with non-zero code",
+			args: []string{"test"},
+			configTOML: `[context.test]
+base_url = "https://api.example.com"
+auth_token = "test-token"
+`,
+			envSetup: func(t *testing.T) {
+				tmpDir := t.TempDir()
+				claudePath := filepath.Join(tmpDir, "claude")
+				err := os.WriteFile(claudePath, []byte("#!/bin/sh\nexit 42"), 0755)
+				require.NoError(t, err)
+				t.Setenv("PATH", tmpDir)
+			},
+			wantCode: 42,
+		},
+		{
+			name: "missing base_url in context",
+			args: []string{"badctx"},
+			configTOML: `[context.badctx]
+auth_token = "test-token"
+`,
+			wantCode: 1,
+		},
+		{
+			name: "invalid base_url format",
+			args: []string{"badurl"},
+			configTOML: `[context.badurl]
+base_url = "not-a-valid-url"
+auth_token = "test-token"
+`,
+			wantCode: 1,
+		},
+		{
+			name: "missing auth_token in context",
+			args: []string{"noauthtoken"},
+			configTOML: `[context.noauthtoken]
+base_url = "https://api.example.com"
+`,
+			wantCode: 1,
+		},
+		{
+			name: "success - provider with forwarded args after separator",
+			args: []string{"test", "--", "--model", "foo"},
+			configTOML: `[context.test]
+base_url = "https://api.example.com"
+auth_token = "test-token"
+`,
+			envSetup: func(t *testing.T) {
+				tmpDir := t.TempDir()
+				claudePath := filepath.Join(tmpDir, "claude")
+				err := os.WriteFile(claudePath, []byte("#!/bin/sh\nexit 0"), 0755)
+				require.NoError(t, err)
+				t.Setenv("PATH", tmpDir)
+			},
+			wantCode: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.toml")
+			err := os.WriteFile(configPath, []byte(tt.configTOML), 0600)
+			require.NoError(t, err)
+			t.Setenv("CCCTX_CONFIG_PATH", configPath)
+
+			if tt.envSetup != nil {
+				tt.envSetup(t)
+			}
+
+			code := runRun(tt.args)
+			assert.Equal(t, tt.wantCode, code)
+		})
+	}
+}

--- a/internal/runner/args.go
+++ b/internal/runner/args.go
@@ -5,6 +5,73 @@ import (
 	"strings"
 )
 
+func validateFlagValue(name, value string) error {
+	if strings.Contains(value, "\n") {
+		return fmt.Errorf("%s value cannot contain newline", name)
+	}
+	return nil
+}
+
+// ExtractFlags extracts --model and --small-fast-model from args before the -- separator.
+// Extracted flags are removed from the returned remaining args.
+func ExtractFlags(args []string) (model, smallFastModel string, remaining []string, err error) {
+	sepIdx := len(args)
+	for i, a := range args {
+		if a == "--" {
+			sepIdx = i
+			break
+		}
+	}
+
+	remaining = make([]string, 0, len(args))
+	preSep := args[:sepIdx]
+	i := 0
+	for i < len(preSep) {
+		switch preSep[i] {
+		case "--model":
+			if i+1 >= len(preSep) {
+				return "", "", []string{}, fmt.Errorf("--model requires a value")
+			}
+			if err := validateFlagValue("--model", preSep[i+1]); err != nil {
+				return "", "", []string{}, err
+			}
+			model = preSep[i+1]
+			i += 2
+		case "--small-fast-model":
+			if i+1 >= len(preSep) {
+				return "", "", []string{}, fmt.Errorf("--small-fast-model requires a value")
+			}
+			if err := validateFlagValue("--small-fast-model", preSep[i+1]); err != nil {
+				return "", "", []string{}, err
+			}
+			smallFastModel = preSep[i+1]
+			i += 2
+		default:
+			remaining = append(remaining, preSep[i])
+			i++
+		}
+	}
+
+	if sepIdx < len(args) {
+		remaining = append(remaining, args[sepIdx:]...)
+	}
+
+	return model, smallFastModel, remaining, nil
+}
+
+// WantsHelp checks if --help or -h appears before -- in args.
+func WantsHelp(args []string) bool {
+	for _, a := range args {
+		if a == "--" {
+			break
+		}
+		if a == "--help" || a == "-h" {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseArgs parses command arguments in a command-agnostic way.
 // It returns the provider name, forwarded target arguments, whether TUI should be used,
 // and any error from ambiguous argument combinations.

--- a/internal/runner/args.go
+++ b/internal/runner/args.go
@@ -1,6 +1,9 @@
 package runner
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // ParseArgs parses command arguments in a command-agnostic way.
 // It returns the provider name, forwarded target arguments, whether TUI should be used,
@@ -22,6 +25,9 @@ func ParseArgs(args []string) (provider string, targetArgs []string, useTUI bool
 			return "", nil, false, fmt.Errorf("at most one argument allowed before --")
 		}
 		if len(contextArgs) == 1 {
+			if strings.HasPrefix(contextArgs[0], "-") {
+				return "", nil, false, fmt.Errorf("flag-like argument '%s' not allowed in provider position", contextArgs[0])
+			}
 			return contextArgs[0], targetArgs, false, nil
 		}
 		return "", targetArgs, true, nil
@@ -31,5 +37,8 @@ func ParseArgs(args []string) (provider string, targetArgs []string, useTUI bool
 		return "", []string{}, true, nil
 	}
 
+	if strings.HasPrefix(args[0], "-") {
+		return "", nil, false, fmt.Errorf("flag-like argument '%s' not allowed in provider position", args[0])
+	}
 	return args[0], args[1:], false, nil
 }

--- a/internal/runner/args_test.go
+++ b/internal/runner/args_test.go
@@ -7,6 +7,197 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		wantModel     string
+		wantSmallFast string
+		wantRemaining []string
+		wantErr       string
+	}{
+		{
+			name:          "no flags returns empty strings and args unchanged",
+			args:          []string{"provider-A"},
+			wantModel:     "",
+			wantSmallFast: "",
+			wantRemaining: []string{"provider-A"},
+		},
+		{
+			name:          "--model before provider",
+			args:          []string{"--model", "foo", "provider-A"},
+			wantModel:     "foo",
+			wantSmallFast: "",
+			wantRemaining: []string{"provider-A"},
+		},
+		{
+			name:          "--model after provider",
+			args:          []string{"provider-A", "--model", "foo"},
+			wantModel:     "foo",
+			wantSmallFast: "",
+			wantRemaining: []string{"provider-A"},
+		},
+		{
+			name:          "--model with separator preserves forwarded args",
+			args:          []string{"provider-A", "--model", "foo", "--", "--help"},
+			wantModel:     "foo",
+			wantSmallFast: "",
+			wantRemaining: []string{"provider-A", "--", "--help"},
+		},
+		{
+			name:          "both flags extracted",
+			args:          []string{"provider-A", "--model", "foo", "--small-fast-model", "bar", "--", "cmd"},
+			wantModel:     "foo",
+			wantSmallFast: "bar",
+			wantRemaining: []string{"provider-A", "--", "cmd"},
+		},
+		{
+			name:          "--model without value returns error",
+			args:          []string{"--model"},
+			wantErr:       "--model requires a value",
+			wantModel:     "",
+			wantSmallFast: "",
+			wantRemaining: []string{},
+		},
+		{
+			name:          "--small-fast-model without value returns error",
+			args:          []string{"--small-fast-model"},
+			wantErr:       "--small-fast-model requires a value",
+			wantModel:     "",
+			wantSmallFast: "",
+			wantRemaining: []string{},
+		},
+		{
+			name:          "--model after separator is NOT extracted",
+			args:          []string{"provider-A", "--", "--model", "foo"},
+			wantModel:     "",
+			wantSmallFast: "",
+			wantRemaining: []string{"provider-A", "--", "--model", "foo"},
+		},
+		{
+			name:          "no provider with flag",
+			args:          []string{"--model", "foo"},
+			wantModel:     "foo",
+			wantSmallFast: "",
+			wantRemaining: []string{},
+		},
+		{
+			name:          "flag value is dash",
+			args:          []string{"provider-A", "--model", "-"},
+			wantModel:     "-",
+			wantSmallFast: "",
+			wantRemaining: []string{"provider-A"},
+		},
+		{
+			name:          "duplicate flags last wins",
+			args:          []string{"provider-A", "--model", "foo", "--model", "bar"},
+			wantModel:     "bar",
+			wantSmallFast: "",
+			wantRemaining: []string{"provider-A"},
+		},
+		{
+			name:          "duplicate --small-fast-model last wins",
+			args:          []string{"provider-A", "--small-fast-model", "foo", "--small-fast-model", "bar"},
+			wantModel:     "",
+			wantSmallFast: "bar",
+			wantRemaining: []string{"provider-A"},
+		},
+		{
+			name:          "flag value looks like another flag",
+			args:          []string{"provider-A", "--model", "--small-fast-model"},
+			wantModel:     "--small-fast-model",
+			wantSmallFast: "",
+			wantRemaining: []string{"provider-A"},
+		},
+		{
+			name:          "separator with no following args",
+			args:          []string{"--model", "foo", "--"},
+			wantModel:     "foo",
+			wantSmallFast: "",
+			wantRemaining: []string{"--"},
+		},
+		{
+			name:          "--model value with newline returns error",
+			args:          []string{"provider-A", "--model", "foo\nbar"},
+			wantErr:       "value cannot contain newline",
+			wantModel:     "",
+			wantSmallFast: "",
+			wantRemaining: []string{},
+		},
+		{
+			name:          "--small-fast-model value with newline returns error",
+			args:          []string{"provider-A", "--small-fast-model", "foo\nbar"},
+			wantErr:       "value cannot contain newline",
+			wantModel:     "",
+			wantSmallFast: "",
+			wantRemaining: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model, sfm, remaining, err := ExtractFlags(tt.args)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Equal(t, []string{}, remaining)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantModel, model)
+			assert.Equal(t, tt.wantSmallFast, sfm)
+			assert.Equal(t, tt.wantRemaining, remaining)
+		})
+	}
+}
+
+func TestWantsHelp(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "--help only",
+			args: []string{"--help"},
+			want: true,
+		},
+		{
+			name: "-h only",
+			args: []string{"-h"},
+			want: true,
+		},
+		{
+			name: "--help after separator is not help",
+			args: []string{"provider-A", "--", "--help"},
+			want: false,
+		},
+		{
+			name: "empty args",
+			args: []string{},
+			want: false,
+		},
+		{
+			name: "--help with provider",
+			args: []string{"provider-A", "--help"},
+			want: true,
+		},
+		{
+			name: "provider only",
+			args: []string{"provider-A"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, WantsHelp(tt.args))
+		})
+	}
+}
+
 func TestParseArgs(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/runner/args_test.go
+++ b/internal/runner/args_test.go
@@ -73,6 +73,30 @@ func TestParseArgs(t *testing.T) {
 			wantTargetArgs: []string{},
 			wantUseTUI:     true,
 		},
+		{
+			name:           "flag-like double dash in provider position",
+			args:           []string{"--model", "foo"},
+			wantProvider:   "",
+			wantTargetArgs: nil,
+			wantUseTUI:     false,
+			wantErr:        "flag-like argument '--model'",
+		},
+		{
+			name:           "flag-like single dash in provider position",
+			args:           []string{"-m"},
+			wantProvider:   "",
+			wantTargetArgs: nil,
+			wantUseTUI:     false,
+			wantErr:        "flag-like argument '-m'",
+		},
+		{
+			name:           "flag-like arg before separator",
+			args:           []string{"--model", "--", "foo"},
+			wantProvider:   "",
+			wantTargetArgs: nil,
+			wantUseTUI:     false,
+			wantErr:        "flag-like argument '--model'",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -89,11 +89,22 @@ func buildEnv(ctx *config.Context, opts Options) []string {
 	}
 	filtered = append(filtered, "ANTHROPIC_BASE_URL="+ctx.BaseURL)
 	filtered = append(filtered, "ANTHROPIC_AUTH_TOKEN="+ctx.AuthToken)
-	if ctx.Model != "" {
-		filtered = append(filtered, "ANTHROPIC_MODEL="+ctx.Model)
+
+	// Priority: CLI flag > config value > omit
+	model := opts.Model
+	if model == "" {
+		model = ctx.Model
 	}
-	if ctx.SmallFastModel != "" {
-		filtered = append(filtered, "ANTHROPIC_SMALL_FAST_MODEL="+ctx.SmallFastModel)
+	if model != "" {
+		filtered = append(filtered, "ANTHROPIC_MODEL="+model)
+	}
+
+	sfm := opts.SmallFastModel
+	if sfm == "" {
+		sfm = ctx.SmallFastModel
+	}
+	if sfm != "" {
+		filtered = append(filtered, "ANTHROPIC_SMALL_FAST_MODEL="+sfm)
 	}
 	return filtered
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -31,6 +32,9 @@ func New(opts Options) (*Runner, error) {
 	if ctx.BaseURL == "" {
 		return nil, fmt.Errorf("context '%s' is missing base_url", opts.ContextName)
 	}
+	if err := validateURL(ctx.BaseURL); err != nil {
+		return nil, fmt.Errorf("context '%s': %w", opts.ContextName, err)
+	}
 	if ctx.AuthToken == "" {
 		return nil, fmt.Errorf("context '%s' is missing auth_token", opts.ContextName)
 	}
@@ -41,6 +45,22 @@ func New(opts Options) (*Runner, error) {
 	return &Runner{ctx: ctx, opts: opts, env: env}, nil
 }
 
+func validateURL(rawURL string) error {
+	if strings.Contains(rawURL, " ") {
+		return fmt.Errorf("invalid base_url: contains spaces")
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid base_url: %w", err)
+	}
+	if u.Scheme == "" {
+		return fmt.Errorf("invalid base_url: missing scheme (e.g., https://)")
+	}
+	return nil
+}
+
+// Run executes the target command. Returns (0, nil) on success, (exitCode, nil) for
+// command exit errors, (1, error) for start failures. Caller is responsible for printing errors.
 func (r *Runner) Run() (int, error) {
 	cmd := exec.Command(r.opts.Target[0], r.opts.Target[1:]...)
 	cmd.Env = r.env

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dsdashun/ccctx/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildEnv(t *testing.T) {
@@ -78,6 +79,58 @@ func TestBuildEnv_InjectionOrder(t *testing.T) {
 		assert.GreaterOrEqual(t, idx, 0, "expected to find %s in env", prefix)
 		assert.GreaterOrEqual(t, idx, lastIdx, "%s should appear after previous injection", prefix)
 		lastIdx = idx
+	}
+}
+
+func TestValidateURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr string
+	}{
+		{
+			name:   "valid https URL",
+			rawURL: "https://api.example.com",
+		},
+		{
+			name:   "valid http URL",
+			rawURL: "http://localhost:8080",
+		},
+		{
+			name:    "missing scheme",
+			rawURL:  "api.example.com",
+			wantErr: "missing scheme",
+		},
+		{
+			name:    "contains spaces",
+			rawURL:  "https://api example.com",
+			wantErr: "contains spaces",
+		},
+		{
+			name:    "empty string",
+			rawURL:  "",
+			wantErr: "missing scheme",
+		},
+		{
+			name:   "valid URL with path",
+			rawURL: "https://api.example.com/v1",
+		},
+		{
+			name:   "valid URL with port",
+			rawURL: "https://api.example.com:8443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateURL(tt.rawURL)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -82,6 +82,107 @@ func TestBuildEnv_InjectionOrder(t *testing.T) {
 	}
 }
 
+func TestBuildEnv_PriorityChain(t *testing.T) {
+	tests := []struct {
+		name      string
+		ctxModel  string
+		ctxSFM    string
+		optsModel string
+		optsSFM   string
+		wantModel string
+		wantSFM   string
+	}{
+		{
+			name:      "opts.Model set, ctx.Model empty → uses opts.Model",
+			ctxModel:  "",
+			optsModel: "claude-opus-4-7",
+			wantModel: "claude-opus-4-7",
+		},
+		{
+			name:      "opts.Model set, ctx.Model set → opts wins",
+			ctxModel:  "claude-sonnet-4-6",
+			optsModel: "claude-opus-4-7",
+			wantModel: "claude-opus-4-7",
+		},
+		{
+			name:      "opts.Model empty, ctx.Model set → uses ctx.Model",
+			ctxModel:  "claude-sonnet-4-6",
+			optsModel: "",
+			wantModel: "claude-sonnet-4-6",
+		},
+		{
+			name:      "both empty → no ANTHROPIC_MODEL",
+			ctxModel:  "",
+			optsModel: "",
+			wantModel: "",
+		},
+		{
+			name:    "opts.SFM set, ctx.SFM empty → uses opts.SFM",
+			ctxSFM:  "",
+			optsSFM: "claude-sonnet-4-6",
+			wantSFM: "claude-sonnet-4-6",
+		},
+		{
+			name:    "opts.SFM set, ctx.SFM set → opts wins",
+			ctxSFM:  "claude-haiku-4-5",
+			optsSFM: "claude-sonnet-4-6",
+			wantSFM: "claude-sonnet-4-6",
+		},
+		{
+			name:    "opts.SFM empty, ctx.SFM set → uses ctx.SFM",
+			ctxSFM:  "claude-haiku-4-5",
+			optsSFM: "",
+			wantSFM: "claude-haiku-4-5",
+		},
+		{
+			name:    "both SFM empty → no ANTHROPIC_SMALL_FAST_MODEL",
+			ctxSFM:  "",
+			optsSFM: "",
+			wantSFM: "",
+		},
+		{
+			name:      "mixed: opts.Model set, ctx.SFM set",
+			optsModel: "claude-opus-4-7",
+			ctxSFM:    "claude-haiku-4-5",
+			wantModel: "claude-opus-4-7",
+			wantSFM:   "claude-haiku-4-5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &config.Context{
+				BaseURL:        "https://api.example.com",
+				AuthToken:      "test-token",
+				Model:          tt.ctxModel,
+				SmallFastModel: tt.ctxSFM,
+			}
+			opts := Options{
+				Model:          tt.optsModel,
+				SmallFastModel: tt.optsSFM,
+			}
+
+			env := buildEnv(ctx, opts)
+
+			if tt.wantModel != "" {
+				assertEnvContains(t, env, "ANTHROPIC_MODEL="+tt.wantModel)
+			} else {
+				for _, e := range env {
+					assert.False(t, strings.HasPrefix(e, "ANTHROPIC_MODEL="), "expected no ANTHROPIC_MODEL, got %q", e)
+				}
+			}
+
+			if tt.wantSFM != "" {
+				assertEnvContains(t, env, "ANTHROPIC_SMALL_FAST_MODEL="+tt.wantSFM)
+			} else {
+				for _, e := range env {
+					assert.False(t, strings.HasPrefix(e, "ANTHROPIC_SMALL_FAST_MODEL="), "expected no ANTHROPIC_SMALL_FAST_MODEL, got %q", e)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateURL(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

Epic 3 focused on hardening the runner and command layer with input validation, robust error handling, and new model override flags for `run` and `exec` commands.

### Story 3.1 — Runner and Command Layer Robustness

- **URL validation**: Added `net/url.Parse` validation in `runner.New()` to reject malformed base URLs early
- **Flag-like arg rejection**: `ParseArgs` now rejects flag-like values (e.g. `--something`) in the provider/context position to prevent confusing errors
- **Error path cleanup**: Refactored `cmd/exec.go` and `cmd/run.go` to avoid direct `os.Exit` calls in error paths, allowing proper error propagation
- **Test coverage**: Added table-driven tests in `cmd/run_test.go`, `runner_test.go` (`TestValidateURL`), and `args_test.go` (flag-like arg cases)

### Story 3.2 — Add `--model` and `--small-fast-model` Override Flags

- **Flag extraction**: Added `ExtractFlags` to parse `--model` and `--small-fast-model` before the `--` separator, keeping them separate from forwarded Claude args
- **Help handling**: Added `WantsHelp` to detect `--help`/`-h` with `DisableFlagParsing` enabled
- **Priority chain**: Implemented CLI flag > config value > omit priority in `buildEnv`, so explicit flags always win
- **Flag parsing isolation**: Set `DisableFlagParsing: true` on both `RunCmd` and `ExecCmd` to preserve the `--` separator semantics
- **Security**: Added newline validation in flag values to prevent environment variable injection
- **Bug fix**: Fixed `cmd.Help()` error handling in `run.go` and `exec.go`
- **Test coverage**: Added `cmd/exec_test.go` with env-capturing mock integration tests, extended `cmd/run_test.go` with model flag tests, and added table-driven tests for `ExtractFlags`, `WantsHelp`, and `buildEnv` priority

### Chores

- Updated sprint status and story docs, marked stories as done
- Added Epic 3 retrospective document with key findings (including discovery of outdated Claude environment variables)
- Updated deferred-work list

## Changed Files

- `cmd/exec.go`, `cmd/run.go` — error handling, flag parsing, help handling
- `cmd/exec_test.go`, `cmd/run_test.go` — new integration tests
- `internal/runner/runner.go` — URL validation
- `internal/runner/args.go` — flag extraction, help detection, newline validation
- `internal/runner/args_test.go`, `internal/runner/runner_test.go` — new tests
- `_bmad-output/` — sprint status, reviews, retrospective, deferred work

## Test plan

- [x] `go test ./...` — all tests pass
- [x] Table-driven unit tests for URL validation, flag parsing, arg parsing
- [x] Integration tests with env-capturing mocks for `run` and `exec` commands
- [x] Edge cases: flag-like args rejected, newline injection blocked, help flag handled